### PR TITLE
small changes

### DIFF
--- a/app/models/concerns/s3_attachment.rb
+++ b/app/models/concerns/s3_attachment.rb
@@ -25,6 +25,8 @@ module S3Attachment
   def file_data
     return nil unless attachment_id.present?
     s3_client.get_object(bucket: BUCKET, key: s3_key).body.read
+  rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::NoSuchKey
+    nil
   end
 
   def s3_key

--- a/missing_files.csv
+++ b/missing_files.csv
@@ -1,0 +1,3 @@
+type,id,s3_key,filename,record_id
+photo,3816,318dafb819fdebc50574ecba24e6aa3d9c0520f63c1d8c2ddc67b304ea01,DSC_0216.JPG,3358
+photo,3817,7d260a38200ee0b9d868c4a9612780cf3e887c17acc793f61d3ff44f3c9f,DSC_0217.JPG,3358


### PR DESCRIPTION
### TL;DR

Added error handling for missing S3 attachments and created a CSV file to track missing files.

### What changed?

- Added rescue blocks in the `file_data` method of `S3Attachment` concern to handle `Aws::S3::Errors::NotFound` and `Aws::S3::Errors::NoSuchKey` exceptions by returning `nil`
- Created a new `missing_files.csv` file that tracks missing photos with their IDs, S3 keys, filenames, and record IDs

### How to test?

1. Attempt to access an attachment that doesn't exist in S3
2. Verify the application gracefully returns `nil` instead of raising an exception
3. Check that the missing files are properly tracked in the CSV file

### Why make this change?

This change improves application resilience by gracefully handling missing S3 files instead of crashing. The CSV tracking file helps identify and potentially recover missing attachments, providing better visibility into data integrity issues.