### PR TITLE
final updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@
 
 /config/credentials/production.key
 .DS_Store
+
+# Tailwind Plus licensed templates (do not commit)
+/vendor/tailwind-plus/

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "recordtemple.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -34,8 +34,7 @@ port ENV.fetch("PORT", 3000)
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-# Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+# Note: Using Sidekiq for background jobs, not Solid Queue
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.


### PR DESCRIPTION
### TL;DR

Updated production configuration and gitignore for Record Temple deployment.

### What changed?

- Updated `.gitignore` to exclude Tailwind Plus licensed templates in `/vendor/tailwind-plus/`
- Changed the mailer host in production from "example.com" to "recordtemple.com"
- Removed Solid Queue configuration from `puma.rb` and added a note about using Sidekiq for background jobs instead

### How to test?

- Verify that emails in production environment use "recordtemple.com" as the host
- Confirm that Sidekiq is properly configured for background job processing
- Check that Tailwind Plus templates are properly excluded from git

### Why make this change?

These changes prepare the application for production deployment with the correct domain name and background job processing setup. The gitignore update ensures that licensed Tailwind Plus templates aren't accidentally committed to the repository.