### PR TITLE
phase 4 complete

### DIFF
--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -70,7 +70,9 @@
         <% if params[:q].present? || params[:has_images].present? || params[:has_audio].present? %>
           <div class="flex flex-wrap gap-2 mb-6">
             <% if params.dig(:q, :artist_name_or_label_name_or_comment_cont).present? %>
-              <%= link_to records_path(params.except(:q).merge(q: params[:q].except(:artist_name_or_label_name_or_comment_cont))),
+              <% clear_search_params = request.query_parameters.deep_dup %>
+              <% clear_search_params[:q]&.delete(:artist_name_or_label_name_or_comment_cont) %>
+              <%= link_to records_path(clear_search_params),
                   class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-olive-100 text-olive-700 text-sm rounded-full hover:bg-olive-200 transition-colors",
                   data: { turbo_frame: "records_list" } do %>
                 Search: "<%= params.dig(:q, :artist_name_or_label_name_or_comment_cont) %>"
@@ -80,7 +82,7 @@
               <% end %>
             <% end %>
             <% if params[:has_images] == "1" %>
-              <%= link_to records_path(params.except(:has_images)),
+              <%= link_to records_path(request.query_parameters.except(:has_images)),
                   class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-olive-100 text-olive-700 text-sm rounded-full hover:bg-olive-200 transition-colors",
                   data: { turbo_frame: "records_list" } do %>
                 Has Images
@@ -90,7 +92,7 @@
               <% end %>
             <% end %>
             <% if params[:has_audio] == "1" %>
-              <%= link_to records_path(params.except(:has_audio)),
+              <%= link_to records_path(request.query_parameters.except(:has_audio)),
                   class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-olive-100 text-olive-700 text-sm rounded-full hover:bg-olive-200 transition-colors",
                   data: { turbo_frame: "records_list" } do %>
                 Has Audio


### PR DESCRIPTION
### TL;DR

Added a public record collection browsing interface with filtering, sorting, and pagination capabilities.

### What changed?

- Added the Pagy gem for pagination support
- Created a new RecordsController with index and show actions for browsing records
- Implemented a comprehensive filtering system using Ransack
- Added UI components for displaying record cards, condition badges, and audio players
- Created Stimulus controllers for audio playback, filter toggles, and mobile menu
- Added helper modules for UI components and form elements
- Updated the application layout with a new navbar and footer
- Applied an olive-themed color palette with custom Tailwind CSS configuration

### How to test?

1. Run `bundle install` to add the Pagy gem
2. Visit `/records` to browse the record collection
3. Test the filtering system by genre, format, condition, and media type
4. Try the search functionality for artists, labels, and notes
5. Test the audio player on record detail pages with audio tracks
6. Verify pagination works correctly with the default 40 items per page
7. Test responsive design on mobile devices

### Why make this change?

This change implements a public-facing interface for browsing the vinyl record collection, making it accessible to users. The implementation focuses on providing a rich browsing experience with comprehensive filtering options, detailed record views, and media playback capabilities. The design uses a consistent olive-themed UI that enhances usability while maintaining visual appeal across different device sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filter links now display with inline icons next to artist, image availability, and audio availability filters.

* **Refactor**
  * Improved query parameter handling in search filters to ensure consistent behavior when applying and removing filter selections across all search operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->