### PR TITLE
autocomplete

### DIFF
--- a/app/controllers/api/artists_controller.rb
+++ b/app/controllers/api/artists_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  class ArtistsController < ApplicationController
+    COLLECTION_USER_ID = 1
+
+    def index
+      query = params[:q].to_s.strip
+
+      return render json: [] if query.length < 2
+
+      artists = Artist
+        .joins(:records)
+        .where(records: { user_id: COLLECTION_USER_ID })
+        .where("artists.name ILIKE ?", "%#{sanitize_sql_like(query)}%")
+        .group("artists.id")
+        .order(Arel.sql("COUNT(records.id) DESC"))
+        .limit(10)
+        .select("artists.id, artists.name, COUNT(records.id) AS record_count")
+
+      render json: artists.map { |a|
+        { id: a.id, name: a.name, count: a.record_count }
+      }
+    end
+
+    private
+
+    def sanitize_sql_like(string)
+      string.gsub(/[\\%_]/) { |x| "\\#{x}" }
+    end
+  end
+end

--- a/app/controllers/api/labels_controller.rb
+++ b/app/controllers/api/labels_controller.rb
@@ -1,0 +1,30 @@
+module Api
+  class LabelsController < ApplicationController
+    COLLECTION_USER_ID = 1
+
+    def index
+      query = params[:q].to_s.strip
+
+      return render json: [] if query.length < 2
+
+      labels = Label
+        .joins(:records)
+        .where(records: { user_id: COLLECTION_USER_ID })
+        .where("labels.name ILIKE ?", "%#{sanitize_sql_like(query)}%")
+        .group("labels.id")
+        .order(Arel.sql("COUNT(records.id) DESC"))
+        .limit(10)
+        .select("labels.id, labels.name, COUNT(records.id) AS record_count")
+
+      render json: labels.map { |l|
+        { id: l.id, name: l.name, count: l.record_count }
+      }
+    end
+
+    private
+
+    def sanitize_sql_like(string)
+      string.gsub(/[\\%_]/) { |x| "\\#{x}" }
+    end
+  end
+end

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,262 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "results", "selected", "hiddenInputs"]
+  static values = {
+    url: String,
+    paramName: String,
+    minLength: { type: Number, default: 2 },
+    debounce: { type: Number, default: 300 }
+  }
+
+  connect() {
+    this.selectedItems = new Map()
+    this.highlightedIndex = -1
+    this.abortController = null
+    this.debounceTimer = null
+
+    this.restoreSelections()
+
+    this.boundHandleKeydown = this.handleKeydown.bind(this)
+    this.inputTarget.addEventListener("keydown", this.boundHandleKeydown)
+
+    this.boundHandleClickOutside = this.handleClickOutside.bind(this)
+    document.addEventListener("click", this.boundHandleClickOutside)
+  }
+
+  disconnect() {
+    this.inputTarget.removeEventListener("keydown", this.boundHandleKeydown)
+    document.removeEventListener("click", this.boundHandleClickOutside)
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+    }
+  }
+
+  restoreSelections() {
+    const hiddenInputs = this.hiddenInputsTarget.querySelectorAll('input[type="hidden"]')
+    hiddenInputs.forEach(input => {
+      const id = input.value
+      const name = input.dataset.name
+      const count = input.dataset.count
+      if (id && name) {
+        this.selectedItems.set(id, { id, name, count: count || 0 })
+      }
+    })
+    this.renderSelected()
+  }
+
+  search() {
+    clearTimeout(this.debounceTimer)
+
+    const query = this.inputTarget.value.trim()
+
+    if (query.length < this.minLengthValue) {
+      this.hideResults()
+      return
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.fetchResults(query)
+    }, this.debounceValue)
+  }
+
+  async fetchResults(query) {
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+    this.abortController = new AbortController()
+
+    try {
+      const url = new URL(this.urlValue, window.location.origin)
+      url.searchParams.set("q", query)
+
+      const response = await fetch(url, {
+        signal: this.abortController.signal,
+        headers: {
+          "Accept": "application/json"
+        }
+      })
+
+      if (!response.ok) throw new Error("Network response was not ok")
+
+      const results = await response.json()
+      this.renderResults(results)
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        console.error("Autocomplete error:", error)
+        this.hideResults()
+      }
+    }
+  }
+
+  renderResults(results) {
+    const filteredResults = results.filter(r => !this.selectedItems.has(String(r.id)))
+
+    if (filteredResults.length === 0) {
+      this.resultsTarget.innerHTML = `
+        <div class="px-4 py-3 text-sm text-olive-500 italic">
+          No results found
+        </div>
+      `
+    } else {
+      this.resultsTarget.innerHTML = filteredResults.map((item, index) => `
+        <button type="button"
+                class="w-full px-4 py-2.5 text-left flex items-center justify-between hover:bg-olive-50 dark:hover:bg-olive-800 focus:bg-olive-50 dark:focus:bg-olive-800 focus:outline-none transition-colors ${index === this.highlightedIndex ? 'bg-olive-50 dark:bg-olive-800' : ''}"
+                data-action="click->autocomplete#select"
+                data-id="${item.id}"
+                data-name="${this.escapeHtml(item.name)}"
+                data-count="${item.count}"
+                data-index="${index}">
+          <span class="text-sm text-olive-900 dark:text-olive-100 truncate">${this.escapeHtml(item.name)}</span>
+          <span class="text-xs text-olive-400 ml-2 shrink-0">${item.count}</span>
+        </button>
+      `).join("")
+    }
+
+    this.highlightedIndex = -1
+    this.showResults()
+  }
+
+  renderSelected() {
+    if (this.selectedItems.size === 0) {
+      this.selectedTarget.innerHTML = ""
+      this.selectedTarget.classList.add("hidden")
+      return
+    }
+
+    this.selectedTarget.classList.remove("hidden")
+    this.selectedTarget.innerHTML = Array.from(this.selectedItems.values()).map(item => `
+      <span class="inline-flex items-center gap-1.5 px-2.5 py-1 bg-olive-100 dark:bg-olive-800 text-olive-700 dark:text-olive-200 text-sm rounded-full">
+        <span class="truncate max-w-32">${this.escapeHtml(item.name)}</span>
+        <button type="button"
+                class="shrink-0 hover:text-olive-900 dark:hover:text-white transition-colors"
+                data-action="click->autocomplete#remove"
+                data-id="${item.id}"
+                aria-label="Remove ${this.escapeHtml(item.name)}">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+        </button>
+      </span>
+    `).join("")
+
+    this.hiddenInputsTarget.innerHTML = Array.from(this.selectedItems.values()).map(item => `
+      <input type="hidden"
+             name="q[${this.paramNameValue}][]"
+             value="${item.id}"
+             data-name="${this.escapeHtml(item.name)}"
+             data-count="${item.count}">
+    `).join("")
+  }
+
+  select(event) {
+    event.preventDefault()
+    const button = event.currentTarget
+    const item = {
+      id: button.dataset.id,
+      name: button.dataset.name,
+      count: button.dataset.count
+    }
+
+    this.selectedItems.set(item.id, item)
+    this.renderSelected()
+    this.inputTarget.value = ""
+    this.hideResults()
+    this.inputTarget.focus()
+
+    this.announceToScreenReader(`${item.name} selected`)
+  }
+
+  remove(event) {
+    event.preventDefault()
+    const id = event.currentTarget.dataset.id
+    const item = this.selectedItems.get(id)
+    this.selectedItems.delete(id)
+    this.renderSelected()
+
+    if (item) {
+      this.announceToScreenReader(`${item.name} removed`)
+    }
+  }
+
+  handleKeydown(event) {
+    const results = this.resultsTarget.querySelectorAll("button[data-index]")
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        if (!this.resultsTarget.classList.contains("hidden") && results.length > 0) {
+          this.highlightedIndex = Math.min(this.highlightedIndex + 1, results.length - 1)
+          this.updateHighlight(results)
+        }
+        break
+
+      case "ArrowUp":
+        event.preventDefault()
+        if (!this.resultsTarget.classList.contains("hidden") && results.length > 0) {
+          this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0)
+          this.updateHighlight(results)
+        }
+        break
+
+      case "Enter":
+        event.preventDefault()
+        if (this.highlightedIndex >= 0 && results[this.highlightedIndex]) {
+          results[this.highlightedIndex].click()
+        }
+        break
+
+      case "Escape":
+        this.hideResults()
+        break
+    }
+  }
+
+  updateHighlight(results) {
+    results.forEach((button, index) => {
+      if (index === this.highlightedIndex) {
+        button.classList.add("bg-olive-50", "dark:bg-olive-800")
+        button.scrollIntoView({ block: "nearest" })
+      } else {
+        button.classList.remove("bg-olive-50", "dark:bg-olive-800")
+      }
+    })
+  }
+
+  handleClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.hideResults()
+    }
+  }
+
+  showResults() {
+    this.resultsTarget.classList.remove("hidden")
+  }
+
+  hideResults() {
+    this.resultsTarget.classList.add("hidden")
+    this.highlightedIndex = -1
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement("div")
+    div.textContent = text
+    return div.innerHTML
+  }
+
+  announceToScreenReader(message) {
+    let announcer = document.getElementById("autocomplete-announcer")
+    if (!announcer) {
+      announcer = document.createElement("div")
+      announcer.id = "autocomplete-announcer"
+      announcer.setAttribute("aria-live", "polite")
+      announcer.setAttribute("aria-atomic", "true")
+      announcer.className = "sr-only"
+      document.body.appendChild(announcer)
+    }
+    announcer.textContent = message
+  }
+}

--- a/app/views/records/_filter_sidebar_content.html.erb
+++ b/app/views/records/_filter_sidebar_content.html.erb
@@ -24,6 +24,76 @@
       </div>
     </div>
 
+    <%# Artist Autocomplete %>
+    <div class="border-t border-olive-100 pt-6"
+         data-controller="autocomplete"
+         data-autocomplete-url-value="<%= api_artists_path %>"
+         data-autocomplete-param-name-value="artist_id_in">
+      <label class="block text-sm font-medium text-olive-700 dark:text-olive-300 mb-2">Artist</label>
+      <div class="relative">
+        <input type="text"
+               data-autocomplete-target="input"
+               data-action="input->autocomplete#search"
+               placeholder="Search artists..."
+               autocomplete="off"
+               class="w-full pl-9 pr-4 py-2.5 text-sm bg-olive-50 dark:bg-olive-900 border-0 rounded-xl text-olive-900 dark:text-olive-100 placeholder-olive-400 dark:placeholder-olive-500 focus:ring-2 focus:ring-olive-500 focus:bg-white dark:focus:bg-olive-800 transition-colors">
+        <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-olive-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+        </svg>
+        <div data-autocomplete-target="results"
+             class="hidden absolute z-50 mt-1 w-full bg-white dark:bg-olive-900 rounded-xl shadow-lg ring-1 ring-olive-900/5 dark:ring-olive-700 max-h-60 overflow-y-auto">
+        </div>
+      </div>
+      <div data-autocomplete-target="selected" class="hidden flex flex-wrap gap-2 mt-3"></div>
+      <div data-autocomplete-target="hiddenInputs">
+        <% Array(params.dig(:q, :artist_id_in)).each do |artist_id| %>
+          <% artist = Artist.find_by(id: artist_id) %>
+          <% if artist %>
+            <input type="hidden"
+                   name="q[artist_id_in][]"
+                   value="<%= artist.id %>"
+                   data-name="<%= artist.name %>"
+                   data-count="<%= artist.records.where(user_id: 1).count %>">
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+
+    <%# Label Autocomplete %>
+    <div class="border-t border-olive-100 pt-6"
+         data-controller="autocomplete"
+         data-autocomplete-url-value="<%= api_labels_path %>"
+         data-autocomplete-param-name-value="label_id_in">
+      <label class="block text-sm font-medium text-olive-700 dark:text-olive-300 mb-2">Label</label>
+      <div class="relative">
+        <input type="text"
+               data-autocomplete-target="input"
+               data-action="input->autocomplete#search"
+               placeholder="Search labels..."
+               autocomplete="off"
+               class="w-full pl-9 pr-4 py-2.5 text-sm bg-olive-50 dark:bg-olive-900 border-0 rounded-xl text-olive-900 dark:text-olive-100 placeholder-olive-400 dark:placeholder-olive-500 focus:ring-2 focus:ring-olive-500 focus:bg-white dark:focus:bg-olive-800 transition-colors">
+        <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-olive-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
+        </svg>
+        <div data-autocomplete-target="results"
+             class="hidden absolute z-50 mt-1 w-full bg-white dark:bg-olive-900 rounded-xl shadow-lg ring-1 ring-olive-900/5 dark:ring-olive-700 max-h-60 overflow-y-auto">
+        </div>
+      </div>
+      <div data-autocomplete-target="selected" class="hidden flex flex-wrap gap-2 mt-3"></div>
+      <div data-autocomplete-target="hiddenInputs">
+        <% Array(params.dig(:q, :label_id_in)).each do |label_id| %>
+          <% label = Label.find_by(id: label_id) %>
+          <% if label %>
+            <input type="hidden"
+                   name="q[label_id_in][]"
+                   value="<%= label.id %>"
+                   data-name="<%= label.name %>"
+                   data-count="<%= label.records.where(user_id: 1).count %>">
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+
     <div data-controller="filter-toggle">
       <button type="button"
               data-action="click->filter-toggle#toggle"

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -81,6 +81,40 @@
                 </svg>
               <% end %>
             <% end %>
+            <%# Artist filter chips %>
+            <% Array(params.dig(:q, :artist_id_in)).each do |artist_id| %>
+              <% artist = Artist.find_by(id: artist_id) %>
+              <% if artist %>
+                <% clear_params = request.query_parameters.deep_dup %>
+                <% clear_params[:q][:artist_id_in] = clear_params[:q][:artist_id_in] - [artist_id.to_s] %>
+                <% clear_params[:q].delete(:artist_id_in) if clear_params[:q][:artist_id_in].empty? %>
+                <%= link_to records_path(clear_params),
+                    class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-olive-100 text-olive-700 text-sm rounded-full hover:bg-olive-200 transition-colors",
+                    data: { turbo_frame: "records_list" } do %>
+                  Artist: "<%= artist.name %>"
+                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                  </svg>
+                <% end %>
+              <% end %>
+            <% end %>
+            <%# Label filter chips %>
+            <% Array(params.dig(:q, :label_id_in)).each do |label_id| %>
+              <% label = Label.find_by(id: label_id) %>
+              <% if label %>
+                <% clear_params = request.query_parameters.deep_dup %>
+                <% clear_params[:q][:label_id_in] = clear_params[:q][:label_id_in] - [label_id.to_s] %>
+                <% clear_params[:q].delete(:label_id_in) if clear_params[:q][:label_id_in].empty? %>
+                <%= link_to records_path(clear_params),
+                    class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-olive-100 text-olive-700 text-sm rounded-full hover:bg-olive-200 transition-colors",
+                    data: { turbo_frame: "records_list" } do %>
+                  Label: "<%= label.name %>"
+                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                  </svg>
+                <% end %>
+              <% end %>
+            <% end %>
             <% if params[:has_images] == "1" %>
               <%= link_to records_path(request.query_parameters.except(:has_images)),
                   class: "inline-flex items-center gap-1.5 px-3 py-1.5 bg-olive-100 text-olive-700 text-sm rounded-full hover:bg-olive-200 transition-colors",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,12 @@ Rails.application.routes.draw do
   get "files/photos/:id", to: "files#photo", as: :photo_file
   get "files/songs/:id", to: "files#song", as: :song_file
 
+  # API endpoints for autocomplete
+  namespace :api do
+    resources :artists, only: [:index]
+    resources :labels, only: [:index]
+  end
+
   # Public record catalog
   resources :records, only: [:index, :show]
 


### PR DESCRIPTION
### TL;DR

Added autocomplete functionality for artists and labels in the record filtering system.

### What changed?

- Created new API controllers (`ArtistsController` and `LabelsController`) to provide search endpoints for autocomplete
- Implemented a Stimulus `autocomplete_controller.js` with features like:
  - Debounced search
  - Keyboard navigation
  - Accessibility support
  - Selected item management
- Added artist and label filter components to the sidebar with autocomplete inputs
- Added filter chips for artists and labels in the records index view
- Updated routes to include the new API endpoints

### How to test?

1. Navigate to the records index page
2. In the filter sidebar, try searching for artists or labels (type at least 2 characters)
3. Select items from the dropdown to filter records
4. Verify that filter chips appear at the top of the records list
5. Test keyboard navigation (arrow keys, enter, escape)
6. Test removing filters by clicking the X on chips
7. Verify that the autocomplete works with partial matches

### Why make this change?

This enhancement improves the user experience when filtering records by artist or label. Instead of requiring users to know exact names, the autocomplete functionality allows for partial matching and shows the number of records for each result. This makes it easier to discover and filter content, especially in large collections where remembering exact artist or label names might be difficult.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added artist and label search with autocomplete functionality in the filter sidebar.
  * Added multi-select filters for artists and labels with removable filter chips for easy filter management and visibility on the records page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->