### PR TITLE
final fixes

### DIFF
--- a/app/services/record_popularity_calculator.rb
+++ b/app/services/record_popularity_calculator.rb
@@ -19,6 +19,7 @@ class RecordPopularityCalculator
     def reload_config!
       @config = nil
       @catalog_counts = nil
+      @attachment_counts = nil
       config
     end
 
@@ -34,6 +35,8 @@ class RecordPopularityCalculator
 
     # Recalculate all records with progress reporting
     def recalculate_all!(dry_run: false, verbose: false)
+      # Clear cached counts to ensure fresh data
+      @attachment_counts = nil
       preload_catalog_counts!
 
       total = Record.count


### PR DESCRIPTION
### TL;DR

Improved record popularity calculation with better caching and database compatibility.

### What changed?

- Added `@attachment_counts = nil` to the `reload_config!` method to ensure proper cache clearing
- Added explicit cache clearing for attachment counts in the `recalculate_all!` method
- Enhanced the popularity statistics rake task with database compatibility:
  - Added fallback logic for non-PostgreSQL databases when calculating median scores
  - Implemented a Ruby-based median calculation when PostgreSQL-specific functions aren't available

### How to test?

1. Run `rake records:popularity_stats` on both PostgreSQL and non-PostgreSQL environments to verify it works in both cases
2. Verify that popularity scores are calculated correctly after calling `reload_config!`
3. Test the `recalculate_all!` method to ensure it uses fresh attachment count data

### Why make this change?

- Fixes a bug where attachment counts weren't properly refreshed during configuration reloads
- Improves database compatibility by adding fallback logic for non-PostgreSQL databases
- Ensures accurate popularity statistics regardless of the database backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Popularity statistics calculation now supports non-PostgreSQL databases, automatically falling back to Ruby-based computation for statistical values when database-specific functions are unavailable
  * Improved data consistency and accuracy by ensuring attachment counts are properly refreshed and recalculated during batch processing operations and system configuration changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->