### PR TITLE
better bread

### DIFF
--- a/app/controllers/concerns/breadcrumbable.rb
+++ b/app/controllers/concerns/breadcrumbable.rb
@@ -16,19 +16,14 @@
 # Usage in views:
 #   <%= render "shared/breadcrumbs" %>
 #
-# Context Detection:
-#   Navigation context is determined solely by URL parameters:
-#   - from=artist&artist_id=123 → shows artist trail
-#   - from=label&label_id=456 → shows label trail
-#   - No params → shows collection trail
-#
-#   This keeps behavior predictable and URLs shareable.
+# Breadcrumbs are objective - they reflect the record's data,
+# not how the user navigated to the page.
 #
 module Breadcrumbable
   extend ActiveSupport::Concern
 
   included do
-    helper_method :breadcrumbs, :navigation_context
+    helper_method :breadcrumbs
   end
 
   # Returns the array of breadcrumb items for the current request
@@ -54,64 +49,5 @@ module Breadcrumbable
   # Clear all breadcrumbs (useful for resetting in specific actions)
   def clear_breadcrumbs
     @breadcrumbs = []
-  end
-
-  # Returns the current navigation context based on URL params
-  def navigation_context
-    @navigation_context ||= detect_navigation_context
-  end
-
-  # Determine breadcrumb context for a record based on URL params
-  #
-  # @param record [Record] The record being viewed
-  # @return [Symbol] The context type (:artist, :label, or :collection)
-  #
-  def breadcrumb_context_for(record)
-    context = detect_navigation_context
-
-    # Validate that the context matches the record's associations
-    case context
-    when :artist
-      # Verify the artist_id in params matches record's artist
-      if params[:artist_id].present? && record.artist_id.to_s == params[:artist_id].to_s
-        :artist
-      else
-        :collection
-      end
-    when :label
-      # Verify the label_id in params matches record's label
-      if params[:label_id].present? && record.label_id.to_s == params[:label_id].to_s
-        :label
-      else
-        :collection
-      end
-    else
-      :collection
-    end
-  end
-
-  # Get the artist from URL params
-  def context_artist
-    return @context_artist if defined?(@context_artist)
-
-    @context_artist = params[:artist_id].present? ? Artist.find_by(id: params[:artist_id]) : nil
-  end
-
-  # Get the label from URL params
-  def context_label
-    return @context_label if defined?(@context_label)
-
-    @context_label = params[:label_id].present? ? Label.find_by(id: params[:label_id]) : nil
-  end
-
-  private
-
-  # Detect navigation context from URL parameters only
-  # This keeps behavior predictable and URLs shareable
-  def detect_navigation_context
-    return :artist if params[:from] == "artist" && params[:artist_id].present?
-    return :label if params[:from] == "label" && params[:label_id].present?
-
-    :collection
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -34,7 +34,7 @@ class RecordsController < ApplicationController
     @record = base_scope.includes(:artist, :label, :genre, :record_format, :price)
                         .find(params[:id])
 
-    # Build contextual breadcrumbs based on navigation source
+    # Build objective breadcrumbs based on record data
     build_record_breadcrumbs(@record)
 
     # Load related records
@@ -55,32 +55,17 @@ class RecordsController < ApplicationController
     Record.where(user_id: COLLECTION_USER_ID)
   end
 
-  # Build contextual breadcrumbs based on how user navigated to this record
-  # Uses multiple detection strategies: URL params, session, referer
+  # Build objective breadcrumbs based on record's data
+  # Hierarchy: Collection > Label > Artist > Title
   def build_record_breadcrumbs(record)
-    context = breadcrumb_context_for(record)
+    add_breadcrumb("Collection", records_path)
 
-    case context
-    when :artist
-      # Use context_artist helper which checks params and session
-      artist = context_artist || record.artist
-      if artist
-        add_breadcrumb("Artists", artists_path)
-        add_breadcrumb(artist.name, artist_path(artist))
-      else
-        add_breadcrumb("Collection", records_path)
-      end
-    when :label
-      # Use context_label helper which checks params and session
-      label = context_label || record.label
-      if label
-        add_breadcrumb("Labels", labels_path)
-        add_breadcrumb(label.name, label_path(label))
-      else
-        add_breadcrumb("Collection", records_path)
-      end
-    else
-      add_breadcrumb("Collection", records_path)
+    if record.label.present?
+      add_breadcrumb(record.label.name, label_path(record.label))
+    end
+
+    if record.artist.present?
+      add_breadcrumb(record.artist.name, artist_path(record.artist))
     end
 
     add_breadcrumb(record.title.presence || "Untitled")

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -73,8 +73,6 @@
         filtered_count: @filtered_count,
         total_count: @total_count,
         form_url: artist_path(@artist),
-        show_filter_chips: false,
-        from: "artist",
-        from_id: @artist.id %>
+        show_filter_chips: false %>
   </div>
 </div>

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -83,8 +83,6 @@
         filtered_count: @filtered_count,
         total_count: @total_count,
         form_url: genre_path(@genre),
-        show_filter_chips: false,
-        from: "genre",
-        from_id: @genre.id %>
+        show_filter_chips: false %>
   </div>
 </div>

--- a/app/views/labels/show.html.erb
+++ b/app/views/labels/show.html.erb
@@ -73,8 +73,6 @@
         filtered_count: @filtered_count,
         total_count: @total_count,
         form_url: label_path(@label),
-        show_filter_chips: false,
-        from: "label",
-        from_id: @label.id %>
+        show_filter_chips: false %>
   </div>
 </div>

--- a/app/views/records/_record_card.html.erb
+++ b/app/views/records/_record_card.html.erb
@@ -1,14 +1,4 @@
-<%# Optional navigation context: pass from: "artist", from_id: @artist.id %>
-<%
-  valid_contexts = %w[artist label]
-  record_url = if defined?(from) && valid_contexts.include?(from) && defined?(from_id) && from_id.present?
-                 context_params = { from: from, "#{from}_id" => from_id }
-                 record_path(record, context_params)
-               else
-                 record_path(record)
-               end
-%>
-<%= link_to record_url,
+<%= link_to record_path(record),
     class: "group block bg-white rounded-2xl shadow-sm ring-1 ring-olive-900/5 hover:shadow-xl hover:ring-olive-900/10 transition-all duration-300 overflow-hidden",
     data: { turbo_frame: "_top" } do %>
 

--- a/app/views/records/_record_collection.html.erb
+++ b/app/views/records/_record_collection.html.erb
@@ -15,8 +15,6 @@
      - show_filter_chips: Show active filter chips (default: true)
      - show_pagination: Show pagination (default: true)
      - grid_cols: Tailwind grid classes for record grid
-     - from: Navigation context type ("artist" or "label") for breadcrumb tracking
-     - from_id: ID of the source artist/label for breadcrumb context
 %>
 
 <% turbo_frame ||= "records_list" %>
@@ -44,8 +42,6 @@
   <%# Record grid %>
   <% grid_options = { records: records } %>
   <% grid_options[:grid_cols] = grid_cols if local_assigns[:grid_cols] %>
-  <% grid_options[:from] = from if local_assigns[:from] %>
-  <% grid_options[:from_id] = from_id if local_assigns[:from_id] %>
   <%= render 'records/record_grid', **grid_options %>
 
   <%# Pagination %>

--- a/app/views/records/_record_grid.html.erb
+++ b/app/views/records/_record_grid.html.erb
@@ -7,8 +7,6 @@
    Optional locals:
      - grid_cols: Tailwind grid classes (default: responsive 2-5 columns)
      - gap: Tailwind gap class (default: gap-5)
-     - from: Navigation context type ("artist" or "label")
-     - from_id: ID of the source artist/label for breadcrumb context
 %>
 
 <% grid_cols ||= "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5" %>
@@ -17,10 +15,7 @@
 <% if records.any? %>
   <div class="grid <%= grid_cols %> <%= gap %>">
     <% records.each do |record| %>
-      <%= render 'records/record_card',
-          record: record,
-          from: (defined?(from) ? from : nil),
-          from_id: (defined?(from_id) ? from_id : nil) %>
+      <%= render 'records/record_card', record: record %>
     <% end %>
   </div>
 <% else %>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -260,7 +260,7 @@
       </div>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
         <% @artist_records.each do |record| %>
-          <%= render 'records/record_card', record: record, from: "artist", from_id: @record.artist_id %>
+          <%= render 'records/record_card', record: record %>
         <% end %>
       </div>
     </div>
@@ -279,7 +279,7 @@
       </div>
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
         <% @label_records.each do |record| %>
-          <%= render 'records/record_card', record: record, from: "label", from_id: @record.label_id %>
+          <%= render 'records/record_card', record: record %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
### TL;DR

Simplified breadcrumb navigation to be data-driven rather than navigation-context driven.

### What changed?

- Removed navigation context tracking from breadcrumbs (eliminated `from` and `from_id` parameters)
- Simplified breadcrumb generation to follow a consistent hierarchy: Collection > Label > Artist > Title
- Removed context detection logic that was previously determining breadcrumbs based on navigation path
- Updated all views to remove navigation context parameters from record links
- Improved median calculation in popularity rake task to use database OFFSET/LIMIT instead of loading all records

### How to test?

1. Navigate through the application and verify breadcrumbs consistently show:
   - Collection > Label > Artist > Record Title
2. Check that record cards link directly to records without additional parameters
3. Run the popularity rake task to verify the median calculation works correctly

### Why make this change?

This change makes breadcrumbs objective and consistent, reflecting the record's actual data hierarchy rather than the user's navigation path. This simplifies the codebase by removing complex context detection logic and makes the user experience more predictable. The breadcrumb trail now represents the actual data relationships rather than how the user arrived at the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified breadcrumb navigation to use a data-driven approach (Collection → Label → Artist → Title)
  * Streamlined record links to consistently use the standard record page path
  * Optimized popularity metric calculations to use database queries, improving performance for large datasets

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->