### PR TITLE
warmup

### DIFF
--- a/app/jobs/variant_warmup_job.rb
+++ b/app/jobs/variant_warmup_job.rb
@@ -1,0 +1,31 @@
+class VariantWarmupJob < ApplicationJob
+  queue_as :default
+
+  # All variant sizes used across the app
+  VARIANT_SIZES = [
+    { resize_to_fill: [ 96, 96 ] },    # lightbox thumbnails
+    { resize_to_fill: [ 160, 160 ] },  # record show thumbnails
+    { resize_to_fill: [ 200, 200 ] },  # discovery cards
+    { resize_to_fill: [ 200, 400 ] },  # discovery cards tall
+    { resize_to_fill: [ 320, 320 ] },  # artist/label/genre covers
+    { resize_to_fill: [ 400, 400 ] },  # record cards
+    { resize_to_fill: [ 600, 600 ] },  # record show hero
+    { resize_to_limit: [ 1200, 1200 ] } # lightbox full size
+  ].freeze
+
+  def perform(blob_id, variant_options = nil)
+    blob = ActiveStorage::Blob.find_by(id: blob_id)
+    return unless blob&.image?
+
+    sizes = variant_options ? [ variant_options ] : VARIANT_SIZES
+
+    sizes.each do |options|
+      begin
+        # This generates and uploads the variant to S3 if it doesn't exist
+        blob.variant(options).processed
+      rescue => e
+        Rails.logger.error "Failed to process variant for blob #{blob_id} with #{options}: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/tasks/variants.rake
+++ b/lib/tasks/variants.rake
@@ -1,0 +1,78 @@
+namespace :variants do
+  desc "Queue all image variants for pre-warming via Sidekiq"
+  task warmup: :environment do
+    puts "Queuing variant warmup jobs..."
+
+    # Get all image blobs attached to records
+    blob_ids = ActiveStorage::Attachment
+      .where(record_type: "Record", name: "images")
+      .pluck(:blob_id)
+      .uniq
+
+    total = blob_ids.count
+    puts "Found #{total} image blobs to process"
+
+    blob_ids.each_with_index do |blob_id, index|
+      VariantWarmupJob.perform_later(blob_id)
+
+      if (index + 1) % 1000 == 0
+        puts "Queued #{index + 1}/#{total} jobs..."
+      end
+    end
+
+    puts "Done! Queued #{total} variant warmup jobs."
+    puts "Monitor progress with: fly logs -a recordtemple"
+  end
+
+  desc "Warmup variants synchronously (for testing, slower)"
+  task warmup_sync: :environment do
+    puts "Processing variants synchronously..."
+
+    blobs = ActiveStorage::Attachment
+      .where(record_type: "Record", name: "images")
+      .includes(:blob)
+      .limit(ENV.fetch("LIMIT", 100).to_i)
+
+    total = blobs.count
+    puts "Processing #{total} images..."
+
+    blobs.each_with_index do |attachment, index|
+      blob = attachment.blob
+      next unless blob&.image?
+
+      VariantWarmupJob::VARIANT_SIZES.each do |options|
+        begin
+          blob.variant(options).processed
+          print "."
+        rescue => e
+          print "x"
+          Rails.logger.error "Failed: blob #{blob.id} with #{options}: #{e.message}"
+        end
+      end
+
+      if (index + 1) % 10 == 0
+        puts " #{index + 1}/#{total}"
+      end
+    end
+
+    puts "\nDone!"
+  end
+
+  desc "Count how many variants need to be generated"
+  task status: :environment do
+    total_blobs = ActiveStorage::Attachment
+      .where(record_type: "Record", name: "images")
+      .count
+
+    total_variants = ActiveStorage::VariantRecord.count
+
+    expected_variants = total_blobs * VariantWarmupJob::VARIANT_SIZES.count
+    missing = expected_variants - total_variants
+
+    puts "Image blobs: #{total_blobs}"
+    puts "Variant sizes: #{VariantWarmupJob::VARIANT_SIZES.count}"
+    puts "Expected variants: #{expected_variants}"
+    puts "Existing variants: #{total_variants}"
+    puts "Missing variants: #{missing} (#{(missing.to_f / expected_variants * 100).round(1)}%)"
+  end
+end


### PR DESCRIPTION
### TL;DR

Replaced Sentry with a more efficient image CDN approach using Rails' built-in proxy mode with CloudFlare caching.

### What changed?

- Removed Sentry Ruby gems and configuration
- Simplified CDN image handling by using Rails' recommended proxy approach instead of direct CDN URLs
- Added `VariantWarmupJob` to pre-generate image variants in the background
- Created rake tasks for variant management (`variants:warmup`, `variants:warmup_sync`, `variants:status`)
- Added SSL certificate fix for development environments
- Updated storage configuration to only make S3 objects public in production

### How to test?

1. Verify images load correctly across the site
2. Run `rake variants:status` to check current variant generation status
3. Test variant generation with `rake variants:warmup_sync LIMIT=10`
4. Confirm SSL certificate handling works in development environment

### Why make this change?

The previous approach used direct CDN URLs which bypassed Rails, making it harder to manage and debug. The new implementation:

1. Uses Rails' recommended approach for CDN integration
2. Provides better error handling and fallbacks
3. Adds systematic variant pre-generation to improve performance
4. Removes dependency on Sentry for error tracking
5. Fixes SSL certificate issues in development environments