### PR TITLE
small potats

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -130,9 +130,16 @@ class Record < ApplicationRecord
       .order(Arel.sql("RANDOM()"))
   }
 
+  # Returns images sorted by filename for consistent ordering
+  # Assumes images are eager-loaded via .with_attached_images
+  def sorted_images
+    return [] unless images.attached?
+    images.sort_by { |img| img.filename.to_s }
+  end
+
+  # Returns the first image when sorted by filename (for cover display)
   def cover
-    return nil unless images.attached? && images.any?
-    images.min_by { |img| img.filename.to_s }
+    sorted_images.first
   end
 
   def song_titles

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -1,7 +1,7 @@
 <div class="mx-auto w-full max-w-4xl px-6 py-12">
   <%= render "shared/breadcrumbs" %>
 
-  <% sorted_images = @record.images.attached? ? @record.images.sort_by { |img| img.filename.to_s } : [] %>
+  <% sorted_images = @record.sorted_images %>
   <% images_data = sorted_images.map { |img| { url: cdn_image_url(img.variant(resize_to_limit: [1200, 1200])), alt: @record.title } } %>
 
   <div class="bg-white rounded-3xl shadow-sm ring-1 ring-olive-900/5 overflow-hidden"


### PR DESCRIPTION
### TL;DR

Added a `sorted_images` method to the Record model and refactored the cover method to use it.

### What changed?

- Added a new `sorted_images` method to the Record model that returns images sorted by filename
- Refactored the `cover` method to use the new `sorted_images` method
- Updated the record show view to use the new `sorted_images` method instead of sorting images inline

### How to test?

1. View a record with multiple attached images
2. Verify that images display in the correct order (sorted by filename)
3. Verify that the cover image is correctly displayed as the first image when sorted by filename

### Why make this change?

This change improves code organization by moving the image sorting logic from the view into the model. It also ensures consistent image ordering across the application and reduces code duplication by centralizing the sorting logic in a single method.