### PR TITLE
performance fixes

### DIFF
--- a/app/controllers/concerns/discovery_covers.rb
+++ b/app/controllers/concerns/discovery_covers.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Concern for batch loading cover images for discovery cards
+# Eliminates N+1 queries by preloading covers for collections of artists/labels/genres
+module DiscoveryCovers
+  extend ActiveSupport::Concern
+
+  private
+
+  # Batch load covers for multiple entities (artists, labels, or genres)
+  # Returns a hash: { entity_id => [cover1, cover2, cover3, cover4] }
+  #
+  # @param entities [ActiveRecord::Relation] Collection of Artist, Label, or Genre
+  # @param entity_type [Symbol] :artist, :label, or :genre
+  # @param user_id [Integer] User ID to scope records
+  # @param limit [Integer] Max covers per entity (default: 4)
+  # @return [Hash<Integer, Array<ActiveStorage::Attachment>>]
+  def batch_load_covers(entities, entity_type, user_id, limit: 4)
+    return {} if entities.blank?
+
+    entity_ids = entities.map(&:id)
+    foreign_key = "#{entity_type}_id"
+
+    # Use window function to get up to `limit` records with images per entity
+    # This is much more efficient than N separate queries
+    ranked_records_sql = <<~SQL
+      SELECT records.*, ROW_NUMBER() OVER (
+        PARTITION BY records.#{foreign_key}
+        ORDER BY records.id
+      ) as row_num
+      FROM records
+      INNER JOIN active_storage_attachments
+        ON active_storage_attachments.record_type = 'Record'
+        AND active_storage_attachments.record_id = records.id
+        AND active_storage_attachments.name = 'images'
+      WHERE records.#{foreign_key} IN (:entity_ids)
+        AND records.user_id = :user_id
+    SQL
+
+    # Wrap in subquery to filter by row_num
+    records_with_images = Record
+      .from("(#{Record.sanitize_sql([ranked_records_sql, entity_ids: entity_ids, user_id: user_id])}) as records")
+      .where("row_num <= ?", limit)
+      .includes(images_attachments: :blob)
+
+    # Group records by entity and extract sorted cover images
+    covers_by_entity = Hash.new { |h, k| h[k] = [] }
+
+    records_with_images.each do |record|
+      entity_id = record.send(foreign_key)
+      # Get the first image sorted by filename (the "cover")
+      cover = record.images.min_by { |img| img.filename.to_s }
+      covers_by_entity[entity_id] << cover if cover
+    end
+
+    covers_by_entity
+  end
+
+  # Preload covers for discovery carousel entities
+  # Call this after loading popular/recent/hidden_gem collections
+  #
+  # @param popular [ActiveRecord::Relation] Popular items collection
+  # @param recent [ActiveRecord::Relation] Recent items collection
+  # @param hidden_gems [ActiveRecord::Relation] Hidden gems collection
+  # @param entity_type [Symbol] :artist, :label, or :genre
+  # @param user_id [Integer] User ID to scope records
+  # @return [Hash<Integer, Array<ActiveStorage::Attachment>>]
+  def preload_discovery_covers(popular:, recent:, hidden_gems:, entity_type:, user_id:)
+    # Combine all entities to load covers in one batch
+    all_entities = [popular, recent, hidden_gems].flatten.compact.uniq(&:id)
+    batch_load_covers(all_entities, entity_type, user_id, limit: 4)
+  end
+
+  # Load a single cover for an entity (for show pages)
+  # Returns the first image from the first record with images
+  #
+  # @param entity_id [Integer] ID of the artist, label, or genre
+  # @param entity_type [Symbol] :artist, :label, or :genre
+  # @param user_id [Integer] User ID to scope records
+  # @return [ActiveStorage::Attachment, nil] The cover image or nil
+  def load_entity_cover(entity_id, entity_type, user_id)
+    foreign_key = "#{entity_type}_id"
+
+    record = Record
+      .joins(:images_attachments)
+      .where(foreign_key => entity_id, user_id: user_id)
+      .includes(images_attachments: :blob)
+      .order(:id)
+      .first
+
+    return nil unless record
+
+    record.images.min_by { |img| img.filename.to_s }
+  end
+end

--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -16,6 +16,7 @@ class DiscoveryController < ApplicationController
     @daily_gems = Record.daily_gems(COLLECTION_USER_ID, 10)
                         .includes(:artist, :label, :genre, :record_format, :price)
                         .with_attached_images
+                        .with_attached_songs
 
     # Cover Wall - fixed size, deterministic daily ordering
     @wall_records = Record.cover_wall(COLLECTION_USER_ID, WALL_SIZE)
@@ -44,6 +45,7 @@ class DiscoveryController < ApplicationController
   def quick_view
     @record = base_scope.includes(:artist, :label, :genre, :record_format, :price)
                         .with_attached_images
+                        .with_attached_songs
                         .find(params[:id])
 
     respond_to do |format|

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -1,5 +1,6 @@
 class GenresController < ApplicationController
   include Pagy::Backend
+  include DiscoveryCovers
 
   # All records are scoped to user_id: 1 (greg2man@gmail.com)
   COLLECTION_USER_ID = 1
@@ -42,6 +43,10 @@ class GenresController < ApplicationController
                               .distinct
                               .pluck(Arel.sql("UPPER(LEFT(genres.name, 1))"))
                               .sort
+
+    # Preload covers for all genres (carousel + grid) to eliminate N+1 queries
+    all_display_genres = [@popular_genres, @recent_genres, @genres].flatten.compact.uniq(&:id)
+    @preloaded_covers = batch_load_covers(all_display_genres, :genre, COLLECTION_USER_ID, limit: 4)
   end
 
   def random
@@ -64,6 +69,9 @@ class GenresController < ApplicationController
     add_breadcrumb("Genres", genres_path)
     add_breadcrumb(@genre.name)
 
+    # Preload cover image to avoid N+1 query
+    @cover = load_entity_cover(@genre.id, :genre, COLLECTION_USER_ID)
+
     # Get records for this genre (scoped to user's collection)
     @q = records_scope.ransack(params[:q])
     @q.sorts = "popularity_score desc" if @q.sorts.empty?
@@ -71,6 +79,7 @@ class GenresController < ApplicationController
     records = @q.result(distinct: true)
                 .includes(:artist, :label, :genre, :record_format, :price)
                 .with_attached_images
+                .with_attached_songs
 
     @pagy, @records = pagy(records)
     @total_count = records_scope.count

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -32,6 +32,7 @@ class RecordsController < ApplicationController
     records = @q.result(distinct: use_distinct)
                 .includes(:artist, :label, :genre, :record_format, :price)
                 .with_attached_images
+                .with_attached_songs
 
     # Apply media filters
     records = records.has_images if params[:has_images] == "1"
@@ -47,6 +48,8 @@ class RecordsController < ApplicationController
 
   def show
     @record = base_scope.includes(:artist, :label, :genre, :record_format, :price)
+                        .with_attached_images
+                        .with_attached_songs
                         .find(params[:id])
 
     # Build objective breadcrumbs based on record data
@@ -57,12 +60,14 @@ class RecordsController < ApplicationController
                                 .where.not(id: @record.id)
                                 .includes(:artist, :label, :genre, :record_format)
                                 .with_attached_images
+                                .with_attached_songs
                                 .limit(5)
 
     @label_records = base_scope.where(label_id: @record.label_id)
                                .where.not(id: @record.id)
                                .includes(:artist, :label, :genre, :record_format)
                                .with_attached_images
+                               .with_attached_songs
                                .limit(5)
   end
 

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -25,7 +25,8 @@
         user_id: ArtistsController::COLLECTION_USER_ID,
         popular_label: "Most Collected",
         recent_label: "Recently Added",
-        hidden_gem_label: "Hidden Gems" %>
+        hidden_gem_label: "Hidden Gems",
+        preloaded_covers: @preloaded_covers %>
   <% end %>
 
   <%# A-Z Navigation %>
@@ -66,7 +67,8 @@
             path: artist_path(artist),
             type: :artist,
             user_id: ArtistsController::COLLECTION_USER_ID,
-            show_collage: true %>
+            show_collage: true,
+            preloaded_covers: @preloaded_covers %>
       <% end %>
     </div>
 

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -4,11 +4,10 @@
   <%# Hero Section %>
   <header class="mb-10">
     <div class="flex flex-col sm:flex-row gap-6 items-start">
-      <%# Artist Cover Art - uses model method for consistent display across pagination %>
+      <%# Artist Cover Art - uses preloaded cover from controller %>
       <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10">
-        <% cover = @artist.cover(ArtistsController::COLLECTION_USER_ID) %>
-        <% if cover %>
-          <%= image_tag cdn_image_url(cover.variant(resize_to_fill: [320, 320])),
+        <% if @cover %>
+          <%= image_tag cdn_image_url(@cover.variant(resize_to_fill: [320, 320])),
               class: "w-full h-full object-cover",
               alt: @artist.name %>
         <% else %>

--- a/app/views/discovery/_gem_card.html.erb
+++ b/app/views/discovery/_gem_card.html.erb
@@ -28,7 +28,7 @@
           <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
             <path d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z"/>
           </svg>
-          <%= record.songs.count %>
+          <%= record.songs.size %>
         </div>
       <% end %>
     </div>

--- a/app/views/genres/index.html.erb
+++ b/app/views/genres/index.html.erb
@@ -24,7 +24,8 @@
         type: :genre,
         user_id: GenresController::COLLECTION_USER_ID,
         popular_label: "Top Genres",
-        recent_label: "Recently Added" %>
+        recent_label: "Recently Added",
+        preloaded_covers: @preloaded_covers %>
   <% end %>
 
   <%# A-Z Navigation %>
@@ -65,7 +66,8 @@
             path: genre_path(genre),
             type: :genre,
             user_id: GenresController::COLLECTION_USER_ID,
-            show_collage: true %>
+            show_collage: true,
+            preloaded_covers: @preloaded_covers %>
       <% end %>
     </div>
 

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -4,11 +4,10 @@
   <%# Hero Section %>
   <header class="mb-10">
     <div class="flex flex-col sm:flex-row gap-6 items-start">
-      <%# Genre Cover Art - uses model method for consistent display across pagination %>
+      <%# Genre Cover Art - uses preloaded cover from controller %>
       <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10">
-        <% cover = @genre.cover(GenresController::COLLECTION_USER_ID) %>
-        <% if cover %>
-          <%= image_tag cdn_image_url(cover.variant(resize_to_fill: [320, 320])),
+        <% if @cover %>
+          <%= image_tag cdn_image_url(@cover.variant(resize_to_fill: [320, 320])),
               class: "w-full h-full object-cover",
               alt: @genre.name %>
         <% else %>

--- a/app/views/labels/index.html.erb
+++ b/app/views/labels/index.html.erb
@@ -25,7 +25,8 @@
         user_id: LabelsController::COLLECTION_USER_ID,
         popular_label: "Top Labels",
         recent_label: "Recently Added",
-        hidden_gem_label: "Hidden Gems" %>
+        hidden_gem_label: "Hidden Gems",
+        preloaded_covers: @preloaded_covers %>
   <% end %>
 
   <%# A-Z Navigation %>
@@ -66,7 +67,8 @@
             path: label_path(label),
             type: :label,
             user_id: LabelsController::COLLECTION_USER_ID,
-            show_collage: true %>
+            show_collage: true,
+            preloaded_covers: @preloaded_covers %>
       <% end %>
     </div>
 

--- a/app/views/labels/show.html.erb
+++ b/app/views/labels/show.html.erb
@@ -4,11 +4,10 @@
   <%# Hero Section %>
   <header class="mb-10">
     <div class="flex flex-col sm:flex-row gap-6 items-start">
-      <%# Label Cover Art - uses model method for consistent display across pagination %>
+      <%# Label Cover Art - uses preloaded cover from controller %>
       <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10">
-        <% cover = @label.cover(LabelsController::COLLECTION_USER_ID) %>
-        <% if cover %>
-          <%= image_tag cdn_image_url(cover.variant(resize_to_fill: [320, 320])),
+        <% if @cover %>
+          <%= image_tag cdn_image_url(@cover.variant(resize_to_fill: [320, 320])),
               class: "w-full h-full object-cover",
               alt: @label.name %>
         <% else %>

--- a/app/views/records/_record_card.html.erb
+++ b/app/views/records/_record_card.html.erb
@@ -21,7 +21,7 @@
         <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
           <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
         </svg>
-        <%= record.songs.count %>
+        <%= record.songs.size %>
       </div>
     <% end %>
   </div>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -125,7 +125,7 @@
 
         <h2 class="font-display text-lg text-olive-950 mb-4">
           Selected Tracks
-          <span class="ml-2 text-sm font-normal text-olive-500">(<%= @record.songs.count %>)</span>
+          <span class="ml-2 text-sm font-normal text-olive-500">(<%= @record.songs.size %>)</span>
         </h2>
 
         <div class="space-y-2">

--- a/app/views/shared/_discovery_card.html.erb
+++ b/app/views/shared/_discovery_card.html.erb
@@ -10,11 +10,21 @@
    Optional locals:
      - featured: Boolean, whether to show as a featured/top card (larger)
      - show_collage: Boolean, whether to show a 2x2 collage instead of single cover
+     - preloaded_covers: Hash of entity_id => [covers] for batch-loaded covers (N+1 optimization)
 %>
 
 <% featured ||= false %>
 <% show_collage ||= false %>
-<% sample_covers = show_collage ? item.sample_covers(4, user_id) : [] %>
+<% preloaded_covers ||= nil %>
+<%# Use preloaded covers if available, otherwise fall back to querying (for backwards compatibility) %>
+<% sample_covers = if preloaded_covers
+     preloaded_covers[item.id] || []
+   elsif show_collage
+     item.sample_covers(4, user_id)
+   else
+     []
+   end %>
+<% single_cover = sample_covers.first %>
 
 <%= link_to path,
     class: "group block bg-white rounded-2xl shadow-sm ring-1 ring-olive-900/5 hover:shadow-xl hover:ring-olive-900/10 hover:-translate-y-1 transition-all duration-300 overflow-hidden" do %>
@@ -48,9 +58,9 @@
           </div>
         <% end %>
       </div>
-    <% elsif item.cover(user_id).present? %>
+    <% elsif single_cover.present? %>
       <%# Single cover %>
-      <%= image_tag cdn_image_url(item.cover(user_id).variant(resize_to_fill: [400, 400])),
+      <%= image_tag cdn_image_url(single_cover.variant(resize_to_fill: [400, 400])),
           class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-500",
           alt: item.name,
           loading: "lazy",

--- a/app/views/shared/_discovery_carousel.html.erb
+++ b/app/views/shared/_discovery_carousel.html.erb
@@ -13,11 +13,13 @@
      - popular_label: Custom label for popular tab (default: "Most Collected")
      - recent_label: Custom label for recent tab (default: "Recently Added")
      - hidden_gem_label: Custom label for hidden gems tab (default: "Hidden Gems")
+     - preloaded_covers: Hash of entity_id => [covers] for N+1 optimization
 %>
 
 <% popular_label ||= "Most Collected" %>
 <% recent_label ||= "Recently Added" %>
 <% hidden_gem_label ||= "Hidden Gems" %>
+<% preloaded_covers ||= nil %>
 
 <%# Determine first available tab dynamically %>
 <% default_tab = popular_items.any? ? "popular" : (recent_items.any? ? "recent" : "gems") %>
@@ -124,7 +126,8 @@
                   path: item_path_helper.call(item),
                   type: type,
                   user_id: user_id,
-                  featured: true %>
+                  featured: true,
+                  preloaded_covers: preloaded_covers %>
             </div>
           <% end %>
         </div>
@@ -173,7 +176,8 @@
                   item: item,
                   path: item_path_helper.call(item),
                   type: type,
-                  user_id: user_id %>
+                  user_id: user_id,
+                  preloaded_covers: preloaded_covers %>
             </div>
           <% end %>
         </div>
@@ -221,7 +225,8 @@
                   item: item,
                   path: item_path_helper.call(item),
                   type: type,
-                  user_id: user_id %>
+                  user_id: user_id,
+                  preloaded_covers: preloaded_covers %>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
### TL;DR

Optimized database queries for artist, label, and genre pages by implementing batch loading of cover images.

### What changed?

- Created a new `DiscoveryCovers` concern with methods to efficiently batch load cover images
- Implemented cover preloading in artists, labels, and genres controllers
- Updated views to use preloaded covers instead of making individual queries
- Added `with_attached_songs` to eager load song attachments in various controllers
- Used `.size` instead of `.count` for songs to avoid additional database queries
- Modified discovery cards and carousels to accept preloaded covers

### How to test?

1. Navigate to the artists, labels, and genres index pages
2. Verify that the discovery carousels and grid cards load quickly with cover images
3. Visit individual artist, label, and genre show pages to confirm cover images display correctly
4. Check record pages to ensure song counts display properly
5. Monitor database queries in the development logs to confirm reduction in N+1 queries

### Why make this change?

This change significantly improves performance by eliminating N+1 queries when loading cover images for collections of artists, labels, and genres. Previously, each entity would make separate database queries to load its cover image, resulting in hundreds of queries on index pages. The new implementation uses window functions to efficiently batch load all required covers in a single query, reducing database load and improving page load times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved page loading speed across the app by optimizing how cover images and song information are retrieved, making navigation and content display faster.
  * Enhanced cover image display throughout the app for a more responsive and smoother browsing experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->