### PR TITLE
login stuff

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -12,7 +12,6 @@
       <div class="mt-10 flex flex-wrap items-center justify-center gap-4">
         <% if current_user.present? %>
           <%= ui_button "Browse Collection", href: records_path, variant: :primary, size: :lg %>
-          <%= ui_button "My Dashboard", href: records_path, variant: :soft, size: :lg %>
         <% else %>
           <%= ui_button "Start Browsing", href: records_path, variant: :primary, size: :lg %>
           <%= ui_button "Sign In", href: users_sign_in_path, variant: :soft, size: :lg %>

--- a/db/migrate/20260106030806_add_index_to_passwordless_sessions_token_digest.rb
+++ b/db/migrate/20260106030806_add_index_to_passwordless_sessions_token_digest.rb
@@ -1,0 +1,5 @@
+class AddIndexToPasswordlessSessionsTokenDigest < ActiveRecord::Migration[8.1]
+  def change
+    add_index :passwordless_sessions, :token_digest, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_06_024053) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_06_030806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -86,6 +86,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_024053) do
     t.text "user_agent"
     t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"
     t.index ["identifier"], name: "index_passwordless_sessions_on_identifier", unique: true
+    t.index ["token_digest"], name: "index_passwordless_sessions_on_token_digest", unique: true
   end
 
   create_table "photos", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
### TL;DR

Improved variant warmup job management, removed duplicate dashboard button, and added index to passwordless sessions.

### What changed?

- Modified `clear_retries` method in `VariantWarmupJob` to only clear retry jobs of class "VariantWarmupJob" instead of all retry jobs
- Updated the notice message to specify "variant warmup retry jobs" for clarity
- Removed an unused `stats` variable in the `calculate_processing_rate` method
- Removed the duplicate "My Dashboard" button from the homepage for logged-in users
- Added a unique index to the `token_digest` column in the `passwordless_sessions` table

### How to test?

1. Visit the admin variants page and test the clear retries functionality
2. Verify that only variant warmup retry jobs are cleared, not all retry jobs
3. Check that the homepage for logged-in users only shows one button ("Browse Collection")
4. Verify that the database migration runs successfully

### Why make this change?

- The previous implementation of `clear_retries` was clearing all retry jobs in Sidekiq, not just the variant warmup jobs, which could affect other background processes
- The duplicate "My Dashboard" button on the homepage was redundant as it pointed to the same location as "Browse Collection"
- Adding an index to `token_digest` improves query performance for passwordless sessions and ensures uniqueness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin panel retry clearing now specifically targets variant warmup jobs, improving efficiency by displaying the exact count of cleared jobs rather than clearing all retries.

* **UI Changes**
  * Removed "My Dashboard" button from home page for logged-in users.

* **Database Updates**
  * Added performance improvements with new indexing on session authentication tokens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->