### PR TITLE
small fixes again

### DIFF
--- a/app/javascript/controllers/image_loader_controller.js
+++ b/app/javascript/controllers/image_loader_controller.js
@@ -8,9 +8,14 @@ import { Controller } from "@hotwired/stimulus"
 //
 export default class extends Controller {
   connect() {
-    // If image is already cached/loaded, remove loading state immediately
-    if (this.element.complete && this.element.naturalHeight !== 0) {
-      this.loaded()
+    // If image already finished loading/erroring before controller connected
+    if (this.element.complete) {
+      if (this.element.naturalHeight !== 0) {
+        this.loaded()
+      } else {
+        // Image failed to load (complete but no dimensions)
+        this.error()
+      }
     }
   }
 

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -5,11 +5,14 @@
   <header class="mb-10">
     <div class="flex flex-col sm:flex-row gap-6 items-start">
       <%# Artist Cover Art - uses preloaded cover from controller %>
-      <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10">
+      <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10 image-skeleton">
         <% if @cover %>
           <%= image_tag cdn_image_url(@cover.variant(ImageVariants::COVER)),
-              class: "w-full h-full object-cover",
-              alt: @artist.name %>
+              class: "w-full h-full object-cover image-loading",
+              alt: @artist.name,
+              loading: "lazy",
+              decoding: "async",
+              data: { controller: "image-loader", action: "load->image-loader#loaded error->image-loader#error" } %>
         <% else %>
           <div class="w-full h-full flex items-center justify-center bg-gradient-to-br from-olive-100 to-olive-200">
             <svg class="w-16 h-16 text-olive-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/views/discovery/_quick_view_content.html.erb
+++ b/app/views/discovery/_quick_view_content.html.erb
@@ -3,11 +3,13 @@
   <audio data-audio-player-target="audio" class="hidden"
          data-action="timeupdate->audio-player#timeUpdate loadedmetadata->audio-player#loadedMetadata ended->audio-player#ended"></audio>
 
-  <div class="md:w-72 md:shrink-0 bg-olive-100 rounded-l-3xl overflow-hidden">
+  <div class="md:w-72 md:shrink-0 bg-olive-100 rounded-l-3xl overflow-hidden image-skeleton">
     <% if @record.cover %>
       <%= image_tag cdn_image_url(@record.cover.variant(ImageVariants::CARD)),
-          class: "w-full h-full object-cover",
-          alt: @record.artist_name || "Album cover" %>
+          class: "w-full h-full object-cover image-loading",
+          alt: @record.artist_name || "Album cover",
+          decoding: "async",
+          data: { controller: "image-loader", action: "load->image-loader#loaded error->image-loader#error" } %>
     <% end %>
   </div>
 

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -5,11 +5,14 @@
   <header class="mb-10">
     <div class="flex flex-col sm:flex-row gap-6 items-start">
       <%# Genre Cover Art - uses preloaded cover from controller %>
-      <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10">
+      <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10 image-skeleton">
         <% if @cover %>
           <%= image_tag cdn_image_url(@cover.variant(ImageVariants::COVER)),
-              class: "w-full h-full object-cover",
-              alt: @genre.name %>
+              class: "w-full h-full object-cover image-loading",
+              alt: @genre.name,
+              loading: "lazy",
+              decoding: "async",
+              data: { controller: "image-loader", action: "load->image-loader#loaded error->image-loader#error" } %>
         <% else %>
           <div class="w-full h-full flex items-center justify-center bg-gradient-to-br from-olive-100 to-olive-200">
             <svg class="w-16 h-16 text-olive-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/views/labels/show.html.erb
+++ b/app/views/labels/show.html.erb
@@ -5,11 +5,14 @@
   <header class="mb-10">
     <div class="flex flex-col sm:flex-row gap-6 items-start">
       <%# Label Cover Art - uses preloaded cover from controller %>
-      <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10">
+      <div class="shrink-0 w-32 h-32 sm:w-40 sm:h-40 rounded-2xl overflow-hidden bg-olive-100 shadow-lg ring-1 ring-olive-900/10 image-skeleton">
         <% if @cover %>
           <%= image_tag cdn_image_url(@cover.variant(ImageVariants::COVER)),
-              class: "w-full h-full object-cover",
-              alt: @label.name %>
+              class: "w-full h-full object-cover image-loading",
+              alt: @label.name,
+              loading: "lazy",
+              decoding: "async",
+              data: { controller: "image-loader", action: "load->image-loader#loaded error->image-loader#error" } %>
         <% else %>
           <div class="w-full h-full flex items-center justify-center bg-gradient-to-br from-olive-100 to-olive-200">
             <svg class="w-16 h-16 text-olive-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -9,15 +9,17 @@
        data-lightbox-images-value="<%= images_data.to_json %>">
     <div class="md:flex">
       <div class="md:w-96 md:shrink-0">
-        <div class="aspect-square bg-olive-100">
+        <div class="aspect-square bg-olive-100 image-skeleton">
           <% if sorted_images.any? %>
             <button type="button"
                     data-action="click->lightbox#open"
                     data-index="0"
                     class="w-full h-full cursor-zoom-in group">
               <%= image_tag cdn_image_url(sorted_images.first.variant(ImageVariants::MAIN)),
-                  class: "w-full h-full object-cover group-hover:opacity-90 transition-opacity",
-                  alt: @record.title %>
+                  class: "w-full h-full object-cover group-hover:opacity-90 transition-opacity image-loading",
+                  alt: @record.title,
+                  decoding: "async",
+                  data: { controller: "image-loader", action: "load->image-loader#loaded error->image-loader#error" } %>
             </button>
           <% else %>
             <div class="w-full h-full flex items-center justify-center bg-gradient-to-br from-olive-100 to-olive-200">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,6 +58,7 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "recordtemple.com" }
+  config.action_mailer.delivery_method = :resend
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {


### PR DESCRIPTION
### TL;DR

Improved image loading experience with proper loading states and error handling.

### What changed?

- Enhanced the `image_loader_controller.js` to properly handle image loading errors
- Added image loading skeleton states to artist, genre, label, record, and discovery views
- Implemented lazy loading and async decoding for images to improve performance
- Added proper image loading classes and Stimulus controller connections
- Added image error handling to gracefully handle failed image loads

### How to test?

1. Visit artist, genre, label, and record pages to observe the improved image loading experience
2. Test with slow network connections to see the skeleton loading states
3. Try accessing the site with images that might fail to load to verify error handling works correctly
4. Check that images properly transition from loading state to loaded state

### Why make this change?

This change improves the user experience by providing visual feedback during image loading and handling error cases gracefully. The skeleton loading states prevent layout shifts and make the site feel more responsive, while lazy loading and async decoding improve performance by deferring non-critical image loading until needed.