### PR TITLE
final changes

### DIFF
--- a/app/views/records/_discogs_badge.html.erb
+++ b/app/views/records/_discogs_badge.html.erb
@@ -1,20 +1,73 @@
 <%# Discogs verification badge - shows when record is matched to Discogs %>
-<% discogs_release = record.discogs_release %>
-<% confidence = record.discogs_confidence.to_i %>
-<% badge_title = "Verified on Discogs#{confidence > 0 ? " (#{confidence}% match)" : ''} - Click to view" %>
+<%
+  discogs_release = record.discogs_release
+  confidence = record.discogs_confidence.to_i
+  matched_at = record.discogs_matched_at
 
-<%= link_to discogs_release.discogs_url,
-    target: "_blank",
-    rel: "noopener noreferrer",
-    class: "group inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-teal-50 text-teal-700 ring-1 ring-inset ring-teal-600/20 hover:bg-teal-100 transition-colors",
-    title: badge_title do %>
-  <%# Official Discogs logo via Simple Icons CDN %>
-  <%= image_tag "https://cdn.simpleicons.org/discogs/0D9488",
-      alt: "Discogs",
-      class: "w-3.5 h-3.5",
-      loading: "lazy" %>
-  <span class="hidden sm:inline">Discogs</span>
-  <svg class="w-3 h-3 text-teal-500 group-hover:text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-  </svg>
-<% end %>
+  # Determine if this is a low confidence match
+  low_confidence = confidence > 0 && confidence < 70
+
+  # Calculate data freshness
+  days_old = matched_at.present? ? ((Time.current - matched_at) / 1.day).to_i : nil
+  stale_data = days_old.present? && days_old > 30
+
+  # Badge styling based on confidence
+  if low_confidence
+    badge_classes = "bg-amber-50 text-amber-700 ring-amber-600/20 hover:bg-amber-100"
+    icon_color = "F59E0B"  # amber-500
+    check_classes = "text-amber-500 group-hover:text-amber-600"
+  else
+    badge_classes = "bg-teal-50 text-teal-700 ring-teal-600/20 hover:bg-teal-100"
+    icon_color = "0D9488"  # teal-600
+    check_classes = "text-teal-500 group-hover:text-teal-600"
+  end
+
+  # Build tooltip
+  badge_parts = ["Verified on Discogs"]
+  badge_parts << "(#{confidence}% match)" if confidence > 0
+  badge_parts << "- Updated #{days_old} days ago" if days_old.present?
+  badge_title = badge_parts.join(" ")
+%>
+
+<div class="inline-flex items-center gap-2">
+  <%# Main badge %>
+  <%= link_to discogs_release.discogs_url,
+      target: "_blank",
+      rel: "noopener noreferrer",
+      class: "group inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ring-1 ring-inset transition-colors #{badge_classes}",
+      title: badge_title do %>
+    <%= image_tag "https://cdn.simpleicons.org/discogs/#{icon_color}",
+        alt: "Discogs",
+        class: "w-3.5 h-3.5",
+        loading: "lazy" %>
+    <span class="hidden sm:inline">Discogs</span>
+    <% if low_confidence %>
+      <%# Warning icon for low confidence %>
+      <svg class="w-3 h-3 <%= check_classes %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+      </svg>
+    <% else %>
+      <%# Checkmark for verified %>
+      <svg class="w-3 h-3 <%= check_classes %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+      </svg>
+    <% end %>
+  <% end %>
+
+  <%# Confidence warning %>
+  <% if low_confidence %>
+    <span class="text-xs text-amber-600" title="This match may need verification">
+      <%= confidence %>% match
+    </span>
+  <% end %>
+
+  <%# Stale data warning %>
+  <% if stale_data %>
+    <span class="inline-flex items-center gap-1 text-xs text-olive-400" title="Data may be outdated">
+      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+      <%= days_old %>d ago
+    </span>
+  <% end %>
+</div>

--- a/app/views/records/_tracklist.html.erb
+++ b/app/views/records/_tracklist.html.erb
@@ -93,8 +93,8 @@
       <% end %>
     </div>
 
-    <%# Link to full Discogs page %>
-    <div class="px-6 py-4 border-t border-olive-100 bg-white/50">
+    <%# Links to Discogs %>
+    <div class="px-6 py-4 border-t border-olive-100 bg-white/50 flex flex-wrap items-center gap-4">
       <a href="<%= discogs_release.discogs_url %>"
          target="_blank"
          rel="noopener noreferrer"
@@ -103,11 +103,24 @@
             alt: "Discogs",
             class: "w-3.5 h-3.5",
             loading: "lazy" %>
-        View full details on Discogs
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        View this release
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
         </svg>
       </a>
+      <% if discogs_release.master_url.present? %>
+        <span class="text-olive-300">·</span>
+        <a href="<%= discogs_release.master_url %>"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="text-sm text-olive-600 hover:text-olive-700 transition-colors inline-flex items-center gap-1.5"
+           title="View all pressings of this album on Discogs">
+          View all pressings
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
+          </svg>
+        </a>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### TL;DR

Enhanced Discogs integration with visual confidence indicators and added links to master releases.

### What changed?

- Improved the Discogs verification badge to visually indicate match confidence levels
- Added amber coloring for low confidence matches (below 70%)
- Added data freshness indicators that show when Discogs data is over 30 days old
- Added explicit confidence percentage display for low confidence matches
- Added a link to view all pressings (master release) when available in the tracklist footer
- Improved the layout of Discogs links in the tracklist footer

### How to test?

1. View records with Discogs matches at different confidence levels:
   - High confidence matches should show a teal badge with checkmark
   - Low confidence matches (<70%) should show an amber badge with warning icon
2. Check records with old Discogs data (>30 days) to verify the age indicator appears
3. Verify that records with a master release show the "View all pressings" link in the tracklist

### Why make this change?

This improves the user experience by providing visual cues about the reliability of Discogs data. Users can now quickly identify records that may need manual verification (low confidence matches) or have potentially outdated information. The additional link to master releases makes it easier for users to explore alternative pressings of the same album.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Discogs badges with confidence indicators to show match reliability
  * Added visual alerts for low-confidence matches and stale data (>30 days old)
  * New optional "View all pressings" link to explore alternate versions
  * Improved layout and organization of Discogs links

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->