### PR TITLE
sidekiq

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server -p 3000
+web: bin/rails server -p 3000 -b 0.0.0.0
 css: bin/rails tailwindcss:watch
 ngrok: ngrok http 3000 --domain=record.ngrok.io

--- a/app/services/discogs_api_client.rb
+++ b/app/services/discogs_api_client.rb
@@ -27,8 +27,8 @@ class DiscogsApiClient
   MIN_REQUEST_INTERVAL = 1.0 # seconds between requests
 
   def initialize(token: nil)
-    @token = token || Rails.application.credentials.dig(:discogs, :api_token)
-    raise AuthenticationError, "Discogs API token not configured" if @token.blank?
+    @token = token || ENV["DISCOGS_API_TOKEN"] || Rails.application.credentials.dig(:discogs, :api_token)
+    raise AuthenticationError, "Discogs API token not configured. Set DISCOGS_API_TOKEN env var or add to credentials." if @token.blank?
     @last_request_at = nil
     @rate_limit_remaining = 60
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,6 +8,7 @@
 :queues:
   - [critical, 3]
   - [default, 2]
+  - [discogs, 2]
   - [migration, 2]
   - [mailers, 1]
   - [low, 1]


### PR DESCRIPTION
### TL;DR

Added environment variable support for Discogs API token and improved development configuration.

### What changed?

- Modified `DiscogsApiClient` to accept the API token from an environment variable (`DISCOGS_API_TOKEN`) as an alternative to Rails credentials
- Updated the error message to provide clearer guidance when the token is missing
- Added a new `discogs` queue to Sidekiq configuration with priority level 2
- Updated the development server binding in `Procfile.dev` to listen on all interfaces (`0.0.0.0`) instead of just localhost

### How to test?

1. Set the `DISCOGS_API_TOKEN` environment variable and verify the API client works without credentials
2. Check that Sidekiq properly processes jobs in the new `discogs` queue
3. Verify that the development server is accessible from other devices on the network using the machine's IP address

### Why make this change?

- Improves development workflow by making the application accessible from other devices on the network
- Provides more flexibility for configuring the Discogs API token, especially in containerized environments
- Adds a dedicated queue for Discogs-related background jobs to better organize and prioritize work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reconfigured web server to listen on all available network interfaces on port 3000, enabling enhanced accessibility from multiple network sources
  * Extended API authentication with environment variable support, allowing token configuration through system variables as an alternative to credential file storage for more flexible deployments
  * Configured new background job processing queue dedicated to external service integration tasks with prioritized handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->