### PR TITLE
small fixes

### DIFF
--- a/db/migrate/20260113151912_add_discogs_price_validation_to_records.rb
+++ b/db/migrate/20260113151912_add_discogs_price_validation_to_records.rb
@@ -1,5 +1,0 @@
-class AddDiscogsPriceValidationToRecords < ActiveRecord::Migration[8.1]
-  def change
-    add_column :records, :discogs_price_validation, :string
-  end
-end

--- a/lib/tasks/discogs.rake
+++ b/lib/tasks/discogs.rake
@@ -190,6 +190,56 @@ namespace :discogs do
     puts ""
   end
 
+  desc "Populate price validation status for all matched records"
+  task populate_validation: :environment do
+    puts "=" * 60
+    puts "Populating Discogs Price Validation Status"
+    puts "=" * 60
+    puts ""
+
+    # Get all matched records with price and discogs data
+    matched_records = Record.joins(:discogs_release)
+                            .where.not(discogs_release_id: nil)
+                            .includes(:price, :discogs_release)
+
+    total = matched_records.count
+    puts "Processing #{total} matched records..."
+    puts ""
+
+    counts = Hash.new(0)
+    processed = 0
+
+    matched_records.find_each do |record|
+      validation = calculate_validation_status(record)
+      record.update_column(:discogs_price_validation, validation)
+      counts[validation] += 1
+      processed += 1
+
+      if (processed % 1000).zero?
+        puts "  Processed #{processed}/#{total}..."
+      end
+    end
+
+    puts ""
+    puts "=" * 60
+    puts "Results:"
+    counts.sort_by { |_, v| -v }.each do |status, count|
+      emoji = case status
+              when "verified" then "✅"
+              when "probable" then "👍"
+              when "uncertain" then "⚠️"
+              when "likely_wrong" then "❌"
+              when "guide_undervalued" then "💰"
+              when "no_price" then "❓"
+              else "❓"
+              end
+      puts "  #{emoji} #{status}: #{count}"
+    end
+    puts ""
+    puts "Total processed: #{processed}"
+    puts ""
+  end
+
   desc "Clear likely_wrong Discogs matches for re-matching"
   task clear_wrong: :environment do
     min_value = (ENV["MIN_VALUE"] || 0).to_i
@@ -310,5 +360,44 @@ namespace :discogs do
     ratio_display = total_guide.to_f.zero? ? "N/A" : "#{(total_discogs.to_f / total_guide * 100).round(1)}%"
     puts "  Ratio: #{ratio_display}"
     puts ""
+  end
+
+  # Helper method to calculate validation status for a record
+  # Compares Discogs lowest_price against price guide midpoint
+  def calculate_validation_status(record)
+    price = record.price
+    discogs_release = record.discogs_release
+
+    # No price guide data
+    return "no_price" if price.nil?
+
+    guide_low = price.price_low.to_f
+    guide_high = price.price_high.to_f
+    guide_mid = (guide_low + guide_high) / 2.0
+
+    # No meaningful guide price
+    return "no_price" if guide_mid <= 0
+
+    discogs_price = discogs_release&.lowest_price.to_f
+
+    # No Discogs price available - can't validate
+    return "uncertain" if discogs_price <= 0
+
+    # Calculate ratio: Discogs price as percentage of guide midpoint
+    ratio = (discogs_price / guide_mid) * 100
+
+    # Categorize based on ratio
+    case ratio
+    when 70..130
+      "verified"        # Within 30% of guide - strong match
+    when 50...70, 130..150
+      "probable"        # Within 50% of guide - likely correct
+    when 30...50, 150..200
+      "uncertain"       # Significant difference - needs review
+    when 200..Float::INFINITY
+      "guide_undervalued"  # Discogs much higher - guide may be outdated
+    else
+      "likely_wrong"    # <30% ratio - probably wrong match
+    end
   end
 end


### PR DESCRIPTION
### TL;DR

Added a price validation system to compare Discogs prices with price guide values for records.

### What changed?

- Removed the migration file that would have added a `discogs_price_validation` column to records
- Added a new Rake task `discogs:populate_validation` that calculates and stores validation status for matched records
- Implemented a helper method `calculate_validation_status` that categorizes records based on the ratio between Discogs price and price guide values
- Created validation categories: "verified", "probable", "uncertain", "likely_wrong", "guide_undervalued", and "no_price"

### How to test?

1. Run the new Rake task: `rake discogs:populate_validation`
2. Check that records have been assigned appropriate validation statuses
3. Verify the output shows counts for each validation category with corresponding emojis
4. Confirm that records with significant price discrepancies are properly flagged

### Why make this change?

This validation system helps identify the accuracy of Discogs matches by comparing prices. It provides a way to:
- Verify that matched records have reasonable price alignment
- Flag potentially incorrect matches for review
- Identify records where the price guide may be outdated compared to current market values
- Improve overall data quality by categorizing the confidence level of each match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Reverted database schema modification related to price validation.

* **New Features**
  * Added a price validation workflow that evaluates record prices against Discogs data and categorizes them as verified, probable, uncertain, likely_wrong, guide_undervalued, or missing price information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->