### PR TITLE
manual match

### DIFF
--- a/app/controllers/admin/discogs_review_controller.rb
+++ b/app/controllers/admin/discogs_review_controller.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Admin
+  class DiscogsReviewController < ApplicationController
+    before_action :require_admin
+    before_action :set_record, only: [:show, :search, :link, :skip]
+
+    # GET /admin/discogs_review
+    def index
+      @scope = params[:scope] || "high_value"
+      @records = review_queue_scope
+        .includes(:artist, :label, :price, :discogs_release)
+        .order("prices.price_high DESC NULLS LAST")
+        .page(params[:page])
+        .per(25)
+
+      @stats = {
+        total: review_queue_scope.count,
+        high_value: unmatched_high_value.count,
+        medium_value: unmatched_medium_value.count,
+        skipped: skipped_records.count
+      }
+    end
+
+    # GET /admin/discogs_review/:id
+    def show
+      @candidates = []
+    end
+
+    # POST /admin/discogs_review/:id/search
+    def search
+      query = params[:query].presence || build_search_query(@record)
+
+      begin
+        client = DiscogsApiClient.new
+        @candidates = client.search(
+          query: query,
+          type: "release",
+          per_page: 10
+        )
+      rescue => e
+        flash.now[:alert] = "Search failed: #{e.message}"
+        @candidates = []
+      end
+
+      render :show
+    end
+
+    # POST /admin/discogs_review/:id/link
+    def link
+      discogs_id = params[:discogs_id].to_i
+      return redirect_with_error("Invalid Discogs ID") if discogs_id <= 0
+
+      begin
+        # Fetch the Discogs release
+        release_service = DiscogsReleaseService.new
+        discogs_release = release_service.find_or_fetch(discogs_id)
+
+        unless discogs_release
+          return redirect_with_error("Could not fetch Discogs release ##{discogs_id}")
+        end
+
+        # Link with manual method and 100% confidence
+        matching_service = DiscogsMatchingService.new(@record)
+        matching_service.link!(discogs_release, confidence: 100, method: "manual")
+
+        redirect_to admin_discogs_review_index_path,
+          notice: "Linked '#{@record.title}' to Discogs ##{discogs_id}"
+      rescue => e
+        redirect_with_error("Link failed: #{e.message}")
+      end
+    end
+
+    # POST /admin/discogs_review/:id/skip
+    def skip
+      @record.update!(discogs_skip_review: true, discogs_skip_reason: params[:reason])
+      redirect_to admin_discogs_review_index_path,
+        notice: "Marked '#{@record.title}' as skipped"
+    end
+
+    private
+
+    def require_admin
+      unless current_user&.admin?
+        redirect_to root_path, alert: "Admin access required"
+      end
+    end
+
+    def set_record
+      @record = Record.find(params[:id])
+    end
+
+    def review_queue_scope
+      case @scope
+      when "high_value"
+        unmatched_high_value
+      when "medium_value"
+        unmatched_medium_value
+      when "skipped"
+        skipped_records
+      else
+        unmatched_high_value
+      end
+    end
+
+    def unmatched_high_value
+      Record.joins(:price)
+        .where(discogs_release_id: nil)
+        .where("prices.price_high >= ?", 100)
+        .where(discogs_skip_review: [nil, false])
+    end
+
+    def unmatched_medium_value
+      Record.joins(:price)
+        .where(discogs_release_id: nil)
+        .where("prices.price_high >= ? AND prices.price_high < ?", 25, 100)
+        .where(discogs_skip_review: [nil, false])
+    end
+
+    def skipped_records
+      Record.where(discogs_skip_review: true)
+    end
+
+    def build_search_query(record)
+      parts = []
+      parts << record.artist&.name if record.artist
+      parts << record.title if record.title.present?
+      parts.join(" - ")
+    end
+
+    def redirect_with_error(message)
+      redirect_to admin_discogs_review_path(@record), alert: message
+    end
+  end
+end

--- a/app/services/discogs_api_client.rb
+++ b/app/services/discogs_api_client.rb
@@ -35,13 +35,28 @@ class DiscogsApiClient
 
   # Search for releases matching criteria
   # Returns hash with :pagination and :results keys
-  def search(artist: nil, label: nil, year: nil, catno: nil, barcode: nil, per_page: 10, page: 1)
+  #
+  # Parameters:
+  #   artist: Artist name
+  #   label: Record label name
+  #   year: Release year
+  #   catno: Catalog number (e.g., "7410", "47-7410")
+  #   barcode: Barcode number
+  #   track: Track/song title (searches within tracklist)
+  #   release_title: Release/album title
+  #   query: Free-form search query
+  #
+  def search(artist: nil, label: nil, year: nil, catno: nil, barcode: nil,
+             track: nil, release_title: nil, query: nil, per_page: 10, page: 1)
     params = { per_page: per_page, page: page, type: "release" }
     params[:artist] = artist if artist.present?
     params[:label] = label if label.present?
     params[:year] = year if year.present?
     params[:catno] = catno if catno.present?
     params[:barcode] = barcode if barcode.present?
+    params[:track] = track if track.present?
+    params[:release_title] = release_title if release_title.present?
+    params[:q] = query if query.present?
 
     get("/database/search", params)
   end

--- a/app/services/discogs_matching_service.rb
+++ b/app/services/discogs_matching_service.rb
@@ -27,10 +27,31 @@ class DiscogsMatchingService
     price: 0.10
   }.freeze
 
+  # Default thresholds for standard records
   THRESHOLDS = {
     auto_high: 85,    # Auto-link with high confidence
-    auto_low: 60,     # Auto-link with lower confidence (lowered from 70 based on Phase 1C research)
+    auto_low: 60,     # Auto-link with lower confidence
     minimum: 50       # Below this, don't create a match
+  }.freeze
+
+  # Tiered thresholds based on record value (Phase 3)
+  # Higher value = stricter thresholds to prevent erroneous data
+  TIERED_THRESHOLDS = {
+    high_value: {     # $100+ records - quality over quantity
+      auto_high: 92,
+      auto_low: 80,
+      minimum: 70
+    },
+    medium_value: {   # $25-99 records - balanced approach
+      auto_high: 85,
+      auto_low: 65,
+      minimum: 55
+    },
+    standard: {       # <$25 records - coverage acceptable
+      auto_high: 85,
+      auto_low: 60,
+      minimum: 50
+    }
   }.freeze
 
   # Format mapping from RecordTemple to Discogs
@@ -65,10 +86,12 @@ class DiscogsMatchingService
     search_results = search_discogs
     return [] if search_results.empty?
 
+    thresholds = thresholds_for_record
+
     search_results
       .first(limit * 2)  # Get extra to filter
       .map { |result| score_candidate(result) }
-      .select { |scored| scored[:score] >= THRESHOLDS[:minimum] }
+      .select { |scored| scored[:score] >= thresholds[:minimum] }
       .sort_by { |scored| -scored[:score] }
       .first(limit)
   end
@@ -85,20 +108,38 @@ class DiscogsMatchingService
     candidates ||= find_candidates(limit: 3)
     return nil if candidates.empty?
 
+    thresholds = thresholds_for_record
     best = candidates.first
-    return nil if best[:score] < THRESHOLDS[:auto_low]
+    return nil if best[:score] < thresholds[:auto_low]
 
     # Get or create the DiscogsRelease
     discogs_release = @release_service.find_or_fetch_from_search_result(
       best[:candidate],
-      fetch_full: best[:score] >= THRESHOLDS[:auto_high]
+      fetch_full: best[:score] >= thresholds[:auto_high]
     )
     return nil unless discogs_release
 
-    method = best[:score] >= THRESHOLDS[:auto_high] ? "auto_high" : "auto_low"
+    method = best[:score] >= thresholds[:auto_high] ? "auto_high" : "auto_low"
     link!(discogs_release, confidence: best[:score], method: method)
 
     discogs_release
+  end
+
+  # Determine value tier for threshold selection
+  def value_tier
+    price_high = @record.price&.price_high.to_f
+    if price_high >= 100
+      :high_value
+    elsif price_high >= 25
+      :medium_value
+    else
+      :standard
+    end
+  end
+
+  # Get thresholds based on record value
+  def thresholds_for_record
+    TIERED_THRESHOLDS[value_tier]
   end
 
   # Manually link a record to a DiscogsRelease
@@ -123,6 +164,12 @@ class DiscogsMatchingService
 
   private
 
+  # Cascading search strategy for better match accuracy:
+  # 1. artist + track (song title) + label - most likely to find correct single
+  # 2. artist + catno (catalog number) + label - very specific
+  # 3. artist + label + year - original approach
+  # 4. artist + label - without year (year might be off)
+  # 5. artist only - broadest fallback
   def search_discogs
     artist = @record.artist&.name || @record.cached_artist
     label = @record.label&.name || @record.cached_label
@@ -131,15 +178,43 @@ class DiscogsMatchingService
 
     return [] if artist.blank?
 
-    # Try most specific search first
+    # Extract song title and catalog number from prices.detail
+    song_titles = extract_titles_from_detail(@record.price&.detail)
+    catalog_number = extract_catalog_number(@record.price&.detail)
+
+    # Strategy 1: Search with track (song title) - best for singles
+    if song_titles.any?
+      song_titles.each do |title|
+        results = @api.search(artist: artist, track: title, label: label, per_page: 10)
+        return results["results"] if results["results"].any?
+      end
+
+      # Try without label (label name might differ)
+      song_titles.each do |title|
+        results = @api.search(artist: artist, track: title, per_page: 10)
+        return results["results"] if results["results"].any?
+      end
+    end
+
+    # Strategy 2: Search with catalog number
+    if catalog_number.present?
+      results = @api.search(artist: artist, catno: catalog_number, label: label, per_page: 10)
+      return results["results"] if results["results"].any?
+
+      # Try catno without label
+      results = @api.search(artist: artist, catno: catalog_number, per_page: 10)
+      return results["results"] if results["results"].any?
+    end
+
+    # Strategy 3: Original approach - artist + label + year
     results = @api.search(artist: artist, label: label, year: year, per_page: 10)
     return results["results"] if results["results"].any?
 
-    # Try without year (year might be off)
+    # Strategy 4: Try without year (year might be off)
     results = @api.search(artist: artist, label: label, per_page: 10)
     return results["results"] if results["results"].any?
 
-    # Try just artist + year
+    # Strategy 5: Try just artist + year
     if year
       results = @api.search(artist: artist, year: year, per_page: 10)
       return results["results"] if results["results"].any?
@@ -148,6 +223,20 @@ class DiscogsMatchingService
     # Fallback to just artist
     results = @api.search(artist: artist, per_page: 10)
     results["results"] || []
+  end
+
+  # Extract catalog number from prices.detail
+  # Formats handled:
+  #   "7410 One Night"     -> "7410"
+  #   "47-7410 One Night"  -> "47-7410"
+  #   "99177/99178 Stormy" -> "99177"
+  def extract_catalog_number(detail)
+    return nil if detail.blank?
+
+    # Match catalog number at start: digits, optionally with prefix/suffix
+    # Pattern: optional prefix (letters+hyphen), digits, optional suffix (hyphen+digits or slash+digits)
+    match = detail.match(/^([A-Za-z]*-?\d+(?:[-\/]\d+)?)\s/)
+    match ? match[1] : nil
   end
 
   def score_candidate(candidate)

--- a/app/views/admin/discogs_review/index.html.erb
+++ b/app/views/admin/discogs_review/index.html.erb
@@ -1,0 +1,126 @@
+<div class="min-h-screen bg-gray-50">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-gray-900">Discogs Review Queue</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        Manually link high-value records to Discogs releases
+      </p>
+    </div>
+
+    <%# Stats cards %>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+      <div class="bg-white rounded-lg shadow p-4">
+        <div class="text-sm font-medium text-gray-500">High Value ($100+)</div>
+        <div class="mt-1 text-2xl font-semibold text-red-600"><%= @stats[:high_value] %></div>
+      </div>
+      <div class="bg-white rounded-lg shadow p-4">
+        <div class="text-sm font-medium text-gray-500">Medium Value ($25-99)</div>
+        <div class="mt-1 text-2xl font-semibold text-amber-600"><%= @stats[:medium_value] %></div>
+      </div>
+      <div class="bg-white rounded-lg shadow p-4">
+        <div class="text-sm font-medium text-gray-500">Skipped</div>
+        <div class="mt-1 text-2xl font-semibold text-gray-400"><%= @stats[:skipped] %></div>
+      </div>
+      <div class="bg-white rounded-lg shadow p-4">
+        <div class="text-sm font-medium text-gray-500">Current Queue</div>
+        <div class="mt-1 text-2xl font-semibold text-teal-600"><%= @stats[:total] %></div>
+      </div>
+    </div>
+
+    <%# Scope tabs %>
+    <div class="border-b border-gray-200 mb-6">
+      <nav class="-mb-px flex space-x-8">
+        <%= link_to "High Value ($100+)",
+            admin_discogs_review_index_path(scope: "high_value"),
+            class: "#{@scope == 'high_value' ? 'border-teal-500 text-teal-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" %>
+        <%= link_to "Medium Value ($25-99)",
+            admin_discogs_review_index_path(scope: "medium_value"),
+            class: "#{@scope == 'medium_value' ? 'border-teal-500 text-teal-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" %>
+        <%= link_to "Skipped",
+            admin_discogs_review_index_path(scope: "skipped"),
+            class: "#{@scope == 'skipped' ? 'border-teal-500 text-teal-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" %>
+      </nav>
+    </div>
+
+    <%# Records table %>
+    <div class="bg-white shadow rounded-lg overflow-hidden">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Record</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Artist</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Label</th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Format</th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Price</th>
+            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% @records.each do |record| %>
+            <tr class="hover:bg-gray-50">
+              <td class="px-6 py-4 whitespace-nowrap">
+                <div class="flex items-center">
+                  <% if record.photos.attached? %>
+                    <%= image_tag record.photos.first.variant(resize_to_fill: [48, 48]),
+                        class: "h-12 w-12 rounded object-cover mr-3",
+                        loading: "lazy" %>
+                  <% else %>
+                    <div class="h-12 w-12 rounded bg-gray-200 mr-3 flex items-center justify-center">
+                      <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
+                      </svg>
+                    </div>
+                  <% end %>
+                  <div>
+                    <div class="text-sm font-medium text-gray-900"><%= record.title %></div>
+                    <div class="text-xs text-gray-500">ID: <%= record.id %></div>
+                  </div>
+                </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <%= record.artist&.name || "—" %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <%= record.label&.name || "—" %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                <%= record.format || "—" %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm text-right">
+                <% if record.price %>
+                  <span class="font-medium text-gray-900">
+                    $<%= number_with_precision(record.price.price_high, precision: 0) %>
+                  </span>
+                <% else %>
+                  <span class="text-gray-400">—</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <%= link_to "Review",
+                    admin_discogs_review_path(record),
+                    class: "text-teal-600 hover:text-teal-900" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <% if @records.empty? %>
+        <div class="text-center py-12">
+          <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+          </svg>
+          <h3 class="mt-2 text-sm font-medium text-gray-900">No records to review</h3>
+          <p class="mt-1 text-sm text-gray-500">All records in this queue have been processed.</p>
+        </div>
+      <% end %>
+    </div>
+
+    <%# Pagination %>
+    <% if @records.respond_to?(:total_pages) && @records.total_pages > 1 %>
+      <div class="mt-6 flex justify-center">
+        <%= paginate @records, theme: 'tailwind' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/discogs_review/show.html.erb
+++ b/app/views/admin/discogs_review/show.html.erb
@@ -1,0 +1,204 @@
+<div class="min-h-screen bg-gray-50">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <%# Back link %>
+    <div class="mb-6">
+      <%= link_to "← Back to Queue", admin_discogs_review_index_path, class: "text-sm text-gray-500 hover:text-gray-700" %>
+    </div>
+
+    <%# Flash messages %>
+    <% if flash[:alert] %>
+      <div class="mb-6 rounded-md bg-red-50 p-4">
+        <div class="flex">
+          <div class="flex-shrink-0">
+            <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+            </svg>
+          </div>
+          <div class="ml-3">
+            <p class="text-sm font-medium text-red-800"><%= flash[:alert] %></p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <%# Left: Record details %>
+      <div class="bg-white shadow rounded-lg overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-200">
+          <h2 class="text-lg font-medium text-gray-900">Record Details</h2>
+        </div>
+        <div class="p-6">
+          <div class="flex items-start space-x-4">
+            <% if @record.photos.attached? %>
+              <%= image_tag @record.photos.first.variant(resize_to_fill: [150, 150]),
+                  class: "h-36 w-36 rounded object-cover",
+                  loading: "lazy" %>
+            <% else %>
+              <div class="h-36 w-36 rounded bg-gray-200 flex items-center justify-center">
+                <svg class="h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
+                </svg>
+              </div>
+            <% end %>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900"><%= @record.title %></h3>
+              <p class="text-gray-600"><%= @record.artist&.name %></p>
+
+              <dl class="mt-4 space-y-2 text-sm">
+                <div class="flex">
+                  <dt class="w-24 text-gray-500">Label:</dt>
+                  <dd class="text-gray-900"><%= @record.label&.name || "—" %></dd>
+                </div>
+                <div class="flex">
+                  <dt class="w-24 text-gray-500">Catalog #:</dt>
+                  <dd class="text-gray-900"><%= @record.catalog_number.presence || "—" %></dd>
+                </div>
+                <div class="flex">
+                  <dt class="w-24 text-gray-500">Format:</dt>
+                  <dd class="text-gray-900"><%= @record.format || "—" %></dd>
+                </div>
+                <div class="flex">
+                  <dt class="w-24 text-gray-500">Year:</dt>
+                  <dd class="text-gray-900"><%= @record.year.presence || "—" %></dd>
+                </div>
+                <div class="flex">
+                  <dt class="w-24 text-gray-500">Price:</dt>
+                  <dd class="text-gray-900 font-medium">
+                    <% if @record.price %>
+                      $<%= number_with_precision(@record.price.price_high, precision: 0) %>
+                    <% else %>
+                      —
+                    <% end %>
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <%# Tracklist if available %>
+          <% if @record.songs.any? %>
+            <div class="mt-6 pt-6 border-t border-gray-200">
+              <h4 class="text-sm font-medium text-gray-900 mb-2">Tracklist</h4>
+              <ol class="text-sm text-gray-600 space-y-1">
+                <% @record.songs.order(:position).each do |song| %>
+                  <li><%= song.position %>. <%= song.title %></li>
+                <% end %>
+              </ol>
+            </div>
+          <% end %>
+
+          <%# Skip button %>
+          <div class="mt-6 pt-6 border-t border-gray-200">
+            <%= form_with url: skip_admin_discogs_review_path(@record), method: :post, local: true, class: "flex items-center space-x-2" do |f| %>
+              <%= f.select :reason,
+                  [["No match found", "no_match"], ["Not on Discogs", "not_on_discogs"], ["Compilation/Various", "compilation"], ["Other", "other"]],
+                  {},
+                  class: "block w-48 rounded-md border-gray-300 shadow-sm focus:border-teal-500 focus:ring-teal-500 text-sm" %>
+              <%= f.submit "Skip This Record",
+                  class: "inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500" %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <%# Right: Discogs search %>
+      <div class="bg-white shadow rounded-lg overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-200">
+          <h2 class="text-lg font-medium text-gray-900">Search Discogs</h2>
+        </div>
+        <div class="p-6">
+          <%# Search form %>
+          <%= form_with url: search_admin_discogs_review_path(@record), method: :post, local: true, class: "mb-6" do |f| %>
+            <div class="flex space-x-2">
+              <%= f.text_field :query,
+                  value: params[:query] || "#{@record.artist&.name} - #{@record.title}",
+                  placeholder: "Search Discogs...",
+                  class: "flex-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-teal-500 focus:ring-teal-500 text-sm" %>
+              <%= f.submit "Search",
+                  class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500" %>
+            </div>
+          <% end %>
+
+          <%# Search results %>
+          <% if @candidates.present? %>
+            <div class="space-y-4">
+              <% @candidates.each do |candidate| %>
+                <div class="border border-gray-200 rounded-lg p-4 hover:border-teal-300 transition-colors">
+                  <div class="flex items-start justify-between">
+                    <div class="flex items-start space-x-3">
+                      <% if candidate["thumb"].present? %>
+                        <%= image_tag candidate["thumb"],
+                            class: "h-16 w-16 rounded object-cover",
+                            loading: "lazy" %>
+                      <% else %>
+                        <div class="h-16 w-16 rounded bg-gray-100 flex items-center justify-center">
+                          <svg class="h-8 w-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
+                          </svg>
+                        </div>
+                      <% end %>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm font-medium text-gray-900 truncate">
+                          <%= candidate["title"] %>
+                        </p>
+                        <p class="text-xs text-gray-500">
+                          <%= candidate["label"]&.first %> • <%= candidate["catno"] %> • <%= candidate["year"] %>
+                        </p>
+                        <p class="text-xs text-gray-400 mt-1">
+                          <%= candidate["format"]&.join(", ") %>
+                        </p>
+                        <p class="text-xs text-gray-400">
+                          Discogs ID: <%= candidate["id"] %>
+                        </p>
+                      </div>
+                    </div>
+                    <div class="flex-shrink-0 ml-4 flex flex-col space-y-2">
+                      <%= link_to "View",
+                          "https://www.discogs.com/release/#{candidate["id"]}",
+                          target: "_blank",
+                          rel: "noopener noreferrer",
+                          class: "inline-flex items-center px-2.5 py-1.5 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50" %>
+                      <%= button_to "Link",
+                          link_admin_discogs_review_path(@record, discogs_id: candidate["id"]),
+                          method: :post,
+                          class: "inline-flex items-center px-2.5 py-1.5 border border-transparent shadow-sm text-xs font-medium rounded text-white bg-teal-600 hover:bg-teal-700" %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% elsif params[:query].present? || request.post? %>
+            <div class="text-center py-8">
+              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+              </svg>
+              <h3 class="mt-2 text-sm font-medium text-gray-900">No results found</h3>
+              <p class="mt-1 text-sm text-gray-500">Try a different search query.</p>
+            </div>
+          <% else %>
+            <div class="text-center py-8">
+              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+              </svg>
+              <h3 class="mt-2 text-sm font-medium text-gray-900">Search Discogs</h3>
+              <p class="mt-1 text-sm text-gray-500">Click Search to find matching releases on Discogs.</p>
+            </div>
+          <% end %>
+
+          <%# Manual ID entry %>
+          <div class="mt-6 pt-6 border-t border-gray-200">
+            <h4 class="text-sm font-medium text-gray-900 mb-2">Or enter Discogs ID directly</h4>
+            <%= form_with url: link_admin_discogs_review_path(@record), method: :post, local: true, class: "flex space-x-2" do |f| %>
+              <%= f.number_field :discogs_id,
+                  placeholder: "e.g. 12345678",
+                  min: 1,
+                  class: "block w-40 rounded-md border-gray-300 shadow-sm focus:border-teal-500 focus:ring-teal-500 text-sm" %>
+              <%= f.submit "Link by ID",
+                  class: "inline-flex items-center px-3 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500" %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,17 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   # mount Avo::Engine, at: Avo.configuration.root_path, constraints: AdminConstraint.new  # Disabled - planned for removal
   mount Sidekiq::Web => "admin/sidekiq", constraints: AdminConstraint.new
+
+  # Admin area
+  namespace :admin, constraints: AdminConstraint.new do
+    resources :discogs_review, only: [:index, :show] do
+      member do
+        post :search
+        post :link
+        post :skip
+      end
+    end
+  end
   passwordless_for :users
 
   # Dev-only auto-login bypass

--- a/db/migrate/20260208193155_add_discogs_skip_fields_to_records.rb
+++ b/db/migrate/20260208193155_add_discogs_skip_fields_to_records.rb
@@ -1,0 +1,6 @@
+class AddDiscogsSkipFieldsToRecords < ActiveRecord::Migration[8.1]
+  def change
+    add_column :records, :discogs_skip_review, :boolean
+    add_column :records, :discogs_skip_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_13_151912) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_08_193155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -182,6 +182,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_13_151912) do
     t.datetime "discogs_matched_at"
     t.string "discogs_price_validation"
     t.bigint "discogs_release_id"
+    t.string "discogs_skip_reason"
+    t.boolean "discogs_skip_review"
     t.integer "genre_id"
     t.integer "identifier_id"
     t.integer "images_count", default: 0, null: false


### PR DESCRIPTION
### TL;DR

Added an admin interface for manually linking high-value records to Discogs releases, with improved matching algorithms for valuable inventory.

### What changed?

- Created a new `DiscogsReviewController` with views for reviewing and manually linking records to Discogs
- Added a queue system that prioritizes records by value tiers (high: $100+, medium: $25-99)
- Enhanced the `DiscogsMatchingService` with tiered confidence thresholds based on record value
- Improved search strategies in the matching service with cascading approaches:
  1. Artist + track (song title) + label
  2. Artist + catalog number + label
  3. Artist + label + year
- Added ability to extract catalog numbers and song titles from record details
- Implemented "skip" functionality to mark records that shouldn't be linked
- Added database fields to track skipped records and reasons

### How to test?

1. Log in as an admin user
2. Navigate to `/admin/discogs_review`
3. Review the queue of high-value records
4. Select a record to review and try searching for matches
5. Test linking a record to a Discogs release
6. Test skipping a record with a reason
7. Verify that linked and skipped records are removed from the queue

### Why make this change?

High-value records ($100+) require more accurate Discogs matching to ensure proper pricing and metadata. The automated matching system works well for standard inventory but can make mistakes with valuable items. This manual review interface allows admins to:

1. Ensure the most valuable inventory has accurate Discogs links
2. Improve data quality for high-value records
3. Skip records that shouldn't be linked (compilations, not on Discogs, etc.)
4. Prioritize work based on inventory value

The tiered confidence thresholds also ensure that more expensive records require higher confidence scores before automatic linking occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin panel for managing Discogs record reviews with search, linking, and skip capabilities
  * Implemented value-based review queuing (high, medium, skipped records)
  * Enhanced Discogs search with multiple criteria options
  * Introduced dynamic matching thresholds based on record value tiers
  * Added ability to skip records with reason tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->