### PR TITLE
final updates

### DIFF
--- a/app/views/admin/discogs_review/index.html.erb
+++ b/app/views/admin/discogs_review/index.html.erb
@@ -24,24 +24,21 @@
     </div>
   </div>
 
-  <%# Pill-style tabs %>
+  <%# Pill-style navigation %>
   <div class="mb-8">
-    <nav class="flex gap-2 flex-wrap" role="tablist">
+    <nav class="flex gap-2 flex-wrap">
       <%= link_to admin_discogs_review_index_path(scope: "high_value"),
-          role: "tab",
-          aria: { selected: @scope == 'high_value' },
+          aria: @scope == 'high_value' ? { current: "page" } : {},
           class: "px-4 py-2.5 text-sm font-medium rounded-full transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-olive-600 focus-visible:ring-offset-2 #{@scope == 'high_value' ? 'bg-olive-950 text-white' : 'bg-olive-200 text-olive-950 hover:bg-olive-300'}" do %>
         High Value ($100+)
       <% end %>
       <%= link_to admin_discogs_review_index_path(scope: "medium_value"),
-          role: "tab",
-          aria: { selected: @scope == 'medium_value' },
+          aria: @scope == 'medium_value' ? { current: "page" } : {},
           class: "px-4 py-2.5 text-sm font-medium rounded-full transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-olive-600 focus-visible:ring-offset-2 #{@scope == 'medium_value' ? 'bg-olive-950 text-white' : 'bg-olive-200 text-olive-950 hover:bg-olive-300'}" do %>
         Medium Value ($25-99)
       <% end %>
       <%= link_to admin_discogs_review_index_path(scope: "skipped"),
-          role: "tab",
-          aria: { selected: @scope == 'skipped' },
+          aria: @scope == 'skipped' ? { current: "page" } : {},
           class: "px-4 py-2.5 text-sm font-medium rounded-full transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-olive-600 focus-visible:ring-offset-2 #{@scope == 'skipped' ? 'bg-olive-950 text-white' : 'bg-olive-200 text-olive-950 hover:bg-olive-300'}" do %>
         Skipped
       <% end %>

--- a/app/views/records/_record_card.html.erb
+++ b/app/views/records/_record_card.html.erb
@@ -73,7 +73,7 @@
 
   <% if show_action && action_path %>
     <%= link_to action_path.call(record),
-        class: "absolute top-3 right-3 inline-flex items-center px-3 py-1.5 text-xs font-medium text-white bg-olive-950 rounded-lg hover:bg-olive-800 transition-colors shadow-lg opacity-0 group-hover:opacity-100" do %>
+        class: "absolute top-3 right-3 inline-flex items-center px-3 py-1.5 text-xs font-medium text-white bg-olive-950 rounded-lg hover:bg-olive-800 transition-colors shadow-lg opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-olive-950" do %>
       <%= action_label %>
     <% end %>
   <% end %>

--- a/app/views/records/_record_sort_bar.html.erb
+++ b/app/views/records/_record_sort_bar.html.erb
@@ -39,7 +39,7 @@
         <button type="button"
                 data-view-toggle-target="gridButton"
                 data-action="click->view-toggle#showGrid"
-                class="p-2 transition-colors bg-white text-olive-700 hover:bg-olive-50"
+                class="p-2 transition-colors <%= default_view == 'grid' ? 'bg-olive-950 text-white' : 'bg-white text-olive-700 hover:bg-olive-50' %>"
                 title="Grid view">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
@@ -48,7 +48,7 @@
         <button type="button"
                 data-view-toggle-target="listButton"
                 data-action="click->view-toggle#showList"
-                class="p-2 transition-colors bg-white text-olive-700 hover:bg-olive-50"
+                class="p-2 transition-colors <%= default_view == 'list' ? 'bg-olive-950 text-white' : 'bg-white text-olive-700 hover:bg-olive-50' %>"
                 title="List view">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>


### PR DESCRIPTION
### TL;DR

Improved accessibility and UI consistency in the record views.

### What changed?

- Updated the pill-style navigation in the Discogs review page:
  - Changed from `role="tablist"` to standard navigation
  - Replaced `aria: { selected: }` with `aria: { current: "page" }` for better accessibility
- Enhanced focus states for the record card action button by adding focus rings
- Fixed the view toggle buttons in the record sort bar to properly highlight the active view state based on the `default_view` parameter

### How to test?

1. Navigate to the admin Discogs review page and verify the pill navigation works correctly
2. Check that the active tab is properly highlighted and has the correct ARIA attributes
3. Test keyboard navigation on record cards to ensure action buttons show proper focus states
4. Switch between grid and list views to confirm the toggle buttons correctly highlight the active view

### Why make this change?

These changes improve accessibility compliance by using proper ARIA attributes for navigation elements and enhancing keyboard focus visibility. The updates also provide better visual feedback to users about the current state of the interface, making the application more intuitive and easier to use for all users, including those using assistive technologies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced keyboard navigation visibility for action buttons with improved focus indicators
  * Clearer active state indicators for view toggle buttons, making the current view mode more apparent
  * Refined tab navigation semantics for better screen reader support

* **Style**
  * Updated focus state styling across interactive elements for improved keyboard navigation experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->