### PR TITLE
phase 1 and 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,24 @@ app/
     └── component_helper.rb    # UI component helpers
 ```
 
+## Discogs Integration
+
+Records are automatically matched to Discogs releases for price validation and metadata enrichment.
+
+### Quick Commands
+
+```bash
+bin/rails discogs:stats              # View matching statistics
+bin/rails discogs:validation_status  # Check validation breakdown
+bin/rails discogs:match              # Match unmatched records
+```
+
+### Admin Review Queue
+
+High-value records ($100+) with uncertain matches can be manually reviewed at `/admin/discogs_review`.
+
+For detailed documentation on the matching system, validation tiers, and re-matching workflows, see [docs/DISCOGS.md](docs/DISCOGS.md).
+
 ## Key Features
 
 - **Full-text Search**: Fast PostgreSQL-based search with fuzzy matching

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -3,6 +3,9 @@ class RecordsController < ApplicationController
   # This is a single-user collection display
   COLLECTION_USER_ID = 1
 
+  before_action :require_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_record, only: [:edit, :update, :destroy]
+
   def index
     add_breadcrumb("Collection")
 
@@ -71,7 +74,61 @@ class RecordsController < ApplicationController
                                .limit(5)
   end
 
+  def new
+    @record = Record.new(user_id: COLLECTION_USER_ID)
+    load_form_options
+  end
+
+  def create
+    @record = Record.new(record_params)
+    @record.user_id = COLLECTION_USER_ID
+
+    if @record.save
+      redirect_to @record, notice: "Record created successfully."
+    else
+      load_form_options
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    load_form_options
+  end
+
+  def update
+    if @record.update(record_params)
+      redirect_to @record, notice: "Record updated successfully."
+    else
+      load_form_options
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @record.destroy
+    redirect_to records_path, notice: "Record deleted."
+  end
+
   private
+
+  def set_record
+    @record = base_scope.find(params[:id])
+  end
+
+  def record_params
+    params.require(:record).permit(
+      :condition, :comment,
+      :artist_id, :label_id, :genre_id, :record_format_id
+    )
+  end
+
+  def load_form_options
+    @conditions = Record.conditions.keys
+    # Artists and Labels use autocomplete search (via /api/artists and /api/labels)
+    # Genre and Format are small enough for standard dropdowns
+    @genres = Genre.order(:name).pluck(:name, :id)
+    @formats = RecordFormat.order(:name).pluck(:name, :id)
+  end
 
   def base_scope
     Record.where(user_id: COLLECTION_USER_ID)

--- a/app/javascript/controllers/form_autocomplete_controller.js
+++ b/app/javascript/controllers/form_autocomplete_controller.js
@@ -1,0 +1,195 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Single-select autocomplete for form fields
+// Usage:
+//   <div data-controller="form-autocomplete"
+//        data-form-autocomplete-url-value="/api/artists"
+//        data-form-autocomplete-param-name-value="record[artist_id]">
+//     <input type="hidden" name="record[artist_id]" data-form-autocomplete-target="hidden">
+//     <input type="text" data-form-autocomplete-target="input" data-action="input->form-autocomplete#search focus->form-autocomplete#search">
+//     <div data-form-autocomplete-target="results" class="hidden"></div>
+//   </div>
+
+export default class extends Controller {
+  static targets = ["input", "results", "hidden"]
+  static values = {
+    url: String,
+    minLength: { type: Number, default: 2 },
+    debounce: { type: Number, default: 300 }
+  }
+
+  connect() {
+    this.highlightedIndex = -1
+    this.abortController = null
+    this.debounceTimer = null
+
+    this.boundHandleKeydown = this.handleKeydown.bind(this)
+    this.inputTarget.addEventListener("keydown", this.boundHandleKeydown)
+
+    this.boundHandleClickOutside = this.handleClickOutside.bind(this)
+    document.addEventListener("click", this.boundHandleClickOutside)
+  }
+
+  disconnect() {
+    this.inputTarget.removeEventListener("keydown", this.boundHandleKeydown)
+    document.removeEventListener("click", this.boundHandleClickOutside)
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer)
+    }
+  }
+
+  search() {
+    clearTimeout(this.debounceTimer)
+
+    const query = this.inputTarget.value.trim()
+
+    if (query.length < this.minLengthValue) {
+      this.hideResults()
+      return
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.fetchResults(query)
+    }, this.debounceValue)
+  }
+
+  async fetchResults(query) {
+    if (this.abortController) {
+      this.abortController.abort()
+    }
+    this.abortController = new AbortController()
+
+    try {
+      const url = new URL(this.urlValue, window.location.origin)
+      url.searchParams.set("q", query)
+
+      const response = await fetch(url, {
+        signal: this.abortController.signal,
+        headers: {
+          "Accept": "application/json"
+        }
+      })
+
+      if (!response.ok) throw new Error("Network response was not ok")
+
+      const results = await response.json()
+      this.renderResults(results)
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        console.error("Autocomplete error:", error)
+        this.hideResults()
+      }
+    }
+  }
+
+  renderResults(results) {
+    if (results.length === 0) {
+      this.resultsTarget.innerHTML = `
+        <div class="px-4 py-3 text-sm text-olive-500 italic">
+          No results found
+        </div>
+      `
+    } else {
+      this.resultsTarget.innerHTML = results.map((item, index) => `
+        <button type="button"
+                class="w-full px-4 py-2.5 text-left flex items-center justify-between hover:bg-olive-50 focus:bg-olive-50 focus:outline-none transition-colors ${index === this.highlightedIndex ? 'bg-olive-50' : ''}"
+                data-action="click->form-autocomplete#select"
+                data-id="${item.id}"
+                data-name="${this.escapeHtml(item.name)}"
+                data-index="${index}">
+          <span class="text-sm text-olive-900 truncate">${this.escapeHtml(item.name)}</span>
+          ${item.count ? `<span class="text-xs text-olive-400 ml-2 shrink-0">${item.count} records</span>` : ''}
+        </button>
+      `).join("")
+    }
+
+    this.highlightedIndex = -1
+    this.showResults()
+  }
+
+  select(event) {
+    event.preventDefault()
+    const button = event.currentTarget
+    const id = button.dataset.id
+    const name = button.dataset.name
+
+    this.hiddenTarget.value = id
+    this.inputTarget.value = name
+    this.hideResults()
+    this.inputTarget.focus()
+  }
+
+  clear() {
+    this.hiddenTarget.value = ""
+    this.inputTarget.value = ""
+    this.inputTarget.focus()
+  }
+
+  handleKeydown(event) {
+    const results = this.resultsTarget.querySelectorAll("button[data-index]")
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        if (!this.resultsTarget.classList.contains("hidden") && results.length > 0) {
+          this.highlightedIndex = Math.min(this.highlightedIndex + 1, results.length - 1)
+          this.updateHighlight(results)
+        }
+        break
+
+      case "ArrowUp":
+        event.preventDefault()
+        if (!this.resultsTarget.classList.contains("hidden") && results.length > 0) {
+          this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0)
+          this.updateHighlight(results)
+        }
+        break
+
+      case "Enter":
+        event.preventDefault()
+        if (this.highlightedIndex >= 0 && results[this.highlightedIndex]) {
+          results[this.highlightedIndex].click()
+        }
+        break
+
+      case "Escape":
+        this.hideResults()
+        break
+    }
+  }
+
+  updateHighlight(results) {
+    results.forEach((button, index) => {
+      if (index === this.highlightedIndex) {
+        button.classList.add("bg-olive-50")
+        button.scrollIntoView({ block: "nearest" })
+      } else {
+        button.classList.remove("bg-olive-50")
+      }
+    })
+  }
+
+  handleClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.hideResults()
+    }
+  }
+
+  showResults() {
+    this.resultsTarget.classList.remove("hidden")
+  }
+
+  hideResults() {
+    this.resultsTarget.classList.add("hidden")
+    this.highlightedIndex = -1
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement("div")
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/views/records/_form.html.erb
+++ b/app/views/records/_form.html.erb
@@ -1,0 +1,126 @@
+<%# Record Form Partial
+   Used by: new.html.erb, edit.html.erb
+
+   Phase 1: Core fields (associations, condition, notes)
+   - No title field: title is computed from artist + label + format + songs
+   - No year fields: years belong to Price model, not Record
+   Phase 2: Will add searchable dropdowns with create-on-the-fly for artists/labels
+   Phase 3: Will add image/audio uploads
+%>
+
+<%= form_with model: record, class: "space-y-6" do |f| %>
+  <% if record.errors.any? %>
+    <div class="rounded-xl bg-red-50 p-4 ring-1 ring-red-200">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+          </svg>
+        </div>
+        <div class="ml-3">
+          <h3 class="text-sm font-medium text-red-800">
+            <%= pluralize(record.errors.count, "error") %> prevented this record from being saved:
+          </h3>
+          <ul class="mt-2 text-sm text-red-700 list-disc list-inside">
+            <% record.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <%# Associations - these define the "title" of the record %>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <%# Artist - Searchable Autocomplete %>
+    <div>
+      <%= f.label :artist_id, "Artist", class: "block text-sm font-medium text-olive-700 mb-1" %>
+      <div data-controller="form-autocomplete"
+           data-form-autocomplete-url-value="/api/artists"
+           class="relative">
+        <%= f.hidden_field :artist_id, data: { form_autocomplete_target: "hidden" } %>
+        <input type="text"
+               value="<%= record.artist&.name %>"
+               placeholder="Search artists..."
+               autocomplete="off"
+               data-form-autocomplete-target="input"
+               data-action="input->form-autocomplete#search focus->form-autocomplete#search"
+               class="block w-full rounded-xl border-olive-300 shadow-sm focus:border-olive-500 focus:ring-olive-500 text-sm">
+        <div data-form-autocomplete-target="results"
+             class="hidden absolute z-50 w-full mt-1 bg-white rounded-xl shadow-lg ring-1 ring-olive-900/5 max-h-60 overflow-auto">
+        </div>
+      </div>
+    </div>
+
+    <%# Label - Searchable Autocomplete %>
+    <div>
+      <%= f.label :label_id, "Label", class: "block text-sm font-medium text-olive-700 mb-1" %>
+      <div data-controller="form-autocomplete"
+           data-form-autocomplete-url-value="/api/labels"
+           class="relative">
+        <%= f.hidden_field :label_id, data: { form_autocomplete_target: "hidden" } %>
+        <input type="text"
+               value="<%= record.label&.name %>"
+               placeholder="Search labels..."
+               autocomplete="off"
+               data-form-autocomplete-target="input"
+               data-action="input->form-autocomplete#search focus->form-autocomplete#search"
+               class="block w-full rounded-xl border-olive-300 shadow-sm focus:border-olive-500 focus:ring-olive-500 text-sm">
+        <div data-form-autocomplete-target="results"
+             class="hidden absolute z-50 w-full mt-1 bg-white rounded-xl shadow-lg ring-1 ring-olive-900/5 max-h-60 overflow-auto">
+        </div>
+      </div>
+    </div>
+
+    <%# Genre - Standard dropdown (manageable size) %>
+    <div>
+      <%= f.label :genre_id, "Genre", class: "block text-sm font-medium text-olive-700 mb-1" %>
+      <%= f.select :genre_id,
+          options_for_select(@genres, record.genre_id),
+          { include_blank: "Select genre..." },
+          class: "block w-full rounded-xl border-olive-300 shadow-sm focus:border-olive-500 focus:ring-olive-500 text-sm" %>
+    </div>
+
+    <%# Format - Standard dropdown (manageable size) %>
+    <div>
+      <%= f.label :record_format_id, "Format", class: "block text-sm font-medium text-olive-700 mb-1" %>
+      <%= f.select :record_format_id,
+          options_for_select(@formats, record.record_format_id),
+          { include_blank: "Select format..." },
+          class: "block w-full rounded-xl border-olive-300 shadow-sm focus:border-olive-500 focus:ring-olive-500 text-sm" %>
+    </div>
+  </div>
+
+  <p class="text-xs text-olive-500">
+    The record title is generated from Artist + Label + Format + Songs.
+  </p>
+
+  <%# Condition %>
+  <div>
+    <%= f.label :condition, class: "block text-sm font-medium text-olive-700 mb-1" %>
+    <%= f.select :condition,
+        options_for_select(@conditions.map { |c| [c.titleize, c] }, record.condition),
+        { include_blank: "Select condition..." },
+        class: "block w-full rounded-xl border-olive-300 shadow-sm focus:border-olive-500 focus:ring-olive-500 text-sm" %>
+    <p class="mt-1 text-xs text-olive-500">Required field</p>
+  </div>
+
+  <%# Comments/Notes %>
+  <div>
+    <%= f.label :comment, "Notes", class: "block text-sm font-medium text-olive-700 mb-1" %>
+    <%= f.text_area :comment,
+        rows: 4,
+        class: "block w-full rounded-xl border-olive-300 shadow-sm focus:border-olive-500 focus:ring-olive-500 text-sm",
+        placeholder: "Additional notes about condition, pressing, provenance, etc." %>
+  </div>
+
+  <%# Submit %>
+  <div class="flex items-center justify-end gap-3 pt-4 border-t border-olive-200">
+    <%= link_to "Cancel",
+        record.persisted? ? record_path(record) : records_path,
+        class: "inline-flex items-center px-4 py-2 border border-olive-300 shadow-sm text-sm font-medium rounded-xl text-olive-700 bg-white hover:bg-olive-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-olive-500 transition-colors" %>
+    <%= f.submit record.persisted? ? "Update Record" : "Create Record",
+        class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-xl text-white bg-olive-950 hover:bg-olive-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-olive-500 transition-colors cursor-pointer" %>
+  </div>
+<% end %>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -1,0 +1,26 @@
+<div class="mx-auto max-w-2xl px-6 py-12">
+  <div class="mb-6">
+    <%= link_to record_path(@record), class: "inline-flex items-center text-sm text-olive-600 hover:text-olive-950 transition-colors" do %>
+      <svg class="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+      </svg>
+      Back to Record
+    <% end %>
+  </div>
+
+  <div class="bg-white shadow-sm rounded-2xl ring-1 ring-olive-900/5 overflow-hidden">
+    <div class="px-6 py-4 border-b border-olive-200 bg-olive-50">
+      <h1 class="font-display text-xl font-medium text-olive-950">Edit Record</h1>
+      <p class="mt-1 text-sm text-olive-600">
+        <% if @record.title.present? %>
+          <%= @record.title %>
+        <% else %>
+          Update record details
+        <% end %>
+      </p>
+    </div>
+    <div class="p-6">
+      <%= render "form", record: @record %>
+    </div>
+  </div>
+</div>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -1,7 +1,20 @@
 <div class="mx-auto w-full max-w-2xl px-6 py-12 md:max-w-3xl lg:max-w-7xl lg:px-10" data-controller="mobile-menu">
   <header class="mb-10">
-    <h1 class="font-display text-4xl tracking-tight text-olive-950 sm:text-5xl">Record Collection</h1>
-    <p class="mt-3 text-lg text-olive-600">Browse <%= number_with_delimiter(@total_count) %> vinyl records</p>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h1 class="font-display text-4xl tracking-tight text-olive-950 sm:text-5xl">Record Collection</h1>
+        <p class="mt-3 text-lg text-olive-600">Browse <%= number_with_delimiter(@total_count) %> vinyl records</p>
+      </div>
+      <% if current_user %>
+        <%= link_to new_record_path,
+            class: "inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-olive-950 rounded-xl hover:bg-olive-800 transition-colors shadow-sm" do %>
+          <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+          </svg>
+          Add Record
+        <% end %>
+      <% end %>
+    </div>
 
     <%# Wide-net search bar %>
     <%= form_with url: records_path, method: :get, class: "mt-6", data: { turbo_frame: "records_list", turbo_action: "advance" } do |f| %>

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -1,0 +1,20 @@
+<div class="mx-auto max-w-2xl px-6 py-12">
+  <div class="mb-6">
+    <%= link_to records_path, class: "inline-flex items-center text-sm text-olive-600 hover:text-olive-950 transition-colors" do %>
+      <svg class="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+      </svg>
+      Back to Collection
+    <% end %>
+  </div>
+
+  <div class="bg-white shadow-sm rounded-2xl ring-1 ring-olive-900/5 overflow-hidden">
+    <div class="px-6 py-4 border-b border-olive-200 bg-olive-50">
+      <h1 class="font-display text-xl font-medium text-olive-950">Add New Record</h1>
+      <p class="mt-1 text-sm text-olive-600">Add a new vinyl record to your collection</p>
+    </div>
+    <div class="p-6">
+      <%= render "form", record: @record %>
+    </div>
+  </div>
+</div>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -65,6 +65,28 @@
           </div>
         </div>
 
+        <%# Admin actions - visible only when logged in %>
+        <% if current_user %>
+          <div class="flex items-center gap-2 mt-4">
+            <%= link_to edit_record_path(@record),
+                class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-olive-700 bg-olive-100 rounded-lg hover:bg-olive-200 transition-colors" do %>
+              <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+              </svg>
+              Edit
+            <% end %>
+            <%= button_to record_path(@record),
+                method: :delete,
+                form: { data: { turbo_confirm: "Are you sure you want to delete this record? This cannot be undone." } },
+                class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-700 bg-red-100 rounded-lg hover:bg-red-200 transition-colors" do %>
+              <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+              </svg>
+              Delete
+            <% end %>
+          </div>
+        <% end %>
+
         <% if @record.genre&.name.present? %>
           <div class="mt-4">
             <%= link_to records_path(q: { genre_id_eq: @record.genre_id }),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,8 @@ Rails.application.routes.draw do
     resources :labels, only: [:index]
   end
 
-  # Public record catalog
-  resources :records, only: [:index, :show]
+  # Public record catalog with authenticated CRUD
+  resources :records
 
   # Discovery pages for artists and labels
   resources :artists, only: [:index, :show] do

--- a/docs/DISCOGS.md
+++ b/docs/DISCOGS.md
@@ -1,0 +1,198 @@
+# Discogs Integration
+
+Record Temple automatically matches records to Discogs releases for price validation and metadata enrichment.
+
+## Overview
+
+The integration provides:
+- **Automatic Matching**: Records are matched to Discogs releases using a cascading search strategy
+- **Price Validation**: Guide prices are compared against Discogs median prices
+- **Confidence Scoring**: Matches are scored based on multiple factors (title, label, catalog number, year)
+- **Manual Review Queue**: Uncertain high-value matches can be reviewed by admins
+
+## Matching System
+
+### Confidence Thresholds
+
+Thresholds vary by record value to prioritize accuracy for expensive items:
+
+| Value Tier | Auto-High | Auto-Low | Minimum |
+|------------|-----------|----------|---------|
+| High ($100+) | 92% | 80% | 70% |
+| Medium ($25-99) | 85% | 65% | 55% |
+| Standard (<$25) | 85% | 60% | 50% |
+
+### Matching Methods
+
+Matches are attempted in order of specificity:
+
+1. **Track matching**: Compare tracklist when available
+2. **Catalog number**: Direct catno match
+3. **Label + Year**: Label name and release year
+4. **Label only**: Just label name
+5. **Artist only**: Fallback to artist search
+
+### Validation Statuses
+
+After matching, records receive a validation status:
+
+| Status | Description |
+|--------|-------------|
+| `verified` | High confidence, prices align well |
+| `probable` | Good confidence, minor price variance |
+| `uncertain` | Lower confidence, needs review |
+| `likely_wrong` | Match appears incorrect |
+| `guide_undervalued` | Discogs price significantly higher |
+| `no_price` | No Discogs pricing available |
+
+## Rake Tasks
+
+### Monitoring
+
+```bash
+# View overall matching statistics
+bin/rails discogs:stats
+
+# Breakdown by validation status
+bin/rails discogs:validation_status
+
+# Compare guide vs Discogs prices
+bin/rails discogs:compare_prices
+
+# View sample matches by validation status
+bin/rails discogs:sample
+```
+
+### Matching
+
+```bash
+# Match unmatched records (default: 500, rate limited)
+bin/rails discogs:match
+
+# Match specific number of records
+bin/rails discogs:match LIMIT=1000
+
+# Enqueue matching as background job
+bin/rails discogs:enqueue
+```
+
+### Maintenance
+
+```bash
+# Preview clearing likely_wrong matches
+bin/rails discogs:clear_wrong DRY_RUN=true
+
+# Clear likely_wrong matches for high-value records
+bin/rails discogs:clear_wrong CONFIRM=yes MIN_VALUE=100
+
+# Recalculate validation status for all matches
+bin/rails discogs:populate_validation
+
+# Reset all Discogs matches (DESTRUCTIVE)
+bin/rails discogs:reset CONFIRM=yes
+```
+
+## Re-Matching Workflow
+
+When matches need to be refreshed (e.g., after algorithm improvements):
+
+```bash
+# 1. Check current state
+bin/rails discogs:stats
+bin/rails discogs:validation_status
+
+# 2. Preview and clear bad matches
+bin/rails discogs:clear_wrong DRY_RUN=true MIN_VALUE=100
+bin/rails discogs:clear_wrong CONFIRM=yes MIN_VALUE=100
+
+# 3. Re-run matching
+bin/rails discogs:match
+
+# 4. Recalculate validation
+bin/rails discogs:populate_validation
+
+# 5. Verify results
+bin/rails discogs:validation_status
+```
+
+## Admin Review Queue
+
+Access the manual review queue at `/admin/discogs_review`.
+
+### Features
+
+- **Value-based tabs**: High Value ($100+), Medium Value ($25-99), Skipped
+- **Discogs search**: Search Discogs directly from the review interface
+- **Manual linking**: Link records to specific Discogs releases by ID
+- **Skip tracking**: Skip records with reason (no match, not on Discogs, compilation, other)
+
+### Manual Link Process
+
+1. Navigate to `/admin/discogs_review`
+2. Select a record from the queue
+3. Use the search to find the correct Discogs release
+4. Click "Link" or enter a Discogs ID directly
+5. Manual links are saved with 100% confidence
+
+## API Rate Limiting
+
+The Discogs API has rate limits. The matching service:
+- Pauses 1 second between API calls
+- Stops after 3 consecutive failures
+- Uses authenticated requests for higher limits
+
+Configure Discogs credentials in Rails credentials:
+
+```yaml
+discogs:
+  consumer_key: YOUR_KEY
+  consumer_secret: YOUR_SECRET
+```
+
+## Database Schema
+
+### discogs_releases table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `discogs_id` | integer | Discogs release ID |
+| `title` | string | Release title |
+| `artist_name` | string | Artist name |
+| `label_name` | string | Label name |
+| `catno` | string | Catalog number |
+| `year` | integer | Release year |
+| `lowest_price` | decimal | Discogs lowest price |
+| `median_price` | decimal | Discogs median price |
+| `highest_price` | decimal | Discogs highest price |
+
+### records table (Discogs fields)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `discogs_release_id` | integer | FK to discogs_releases |
+| `discogs_match_confidence` | decimal | Match confidence (0-100) |
+| `discogs_match_method` | string | How match was found |
+| `discogs_price_validation` | string | Validation status |
+| `discogs_matched_at` | datetime | When matched |
+
+## Services
+
+### DiscogsApiClient
+
+Low-level API client for Discogs. Handles authentication and rate limiting.
+
+```ruby
+client = DiscogsApiClient.new
+results = client.search_releases("Artist Name", "Album Title")
+release = client.get_release(12345)
+```
+
+### DiscogsMatchingService
+
+High-level matching logic. Finds best Discogs match for a record.
+
+```ruby
+service = DiscogsMatchingService.new
+service.match_record(record)
+service.match_unmatched_records(limit: 500)
+```


### PR DESCRIPTION
### TL;DR

Added record management features including create, edit, and delete functionality, along with Discogs integration for price validation and metadata enrichment.

### What changed?

- Added full CRUD operations for records with form views and controllers
- Implemented a form autocomplete component for artist and label selection
- Added "Add Record" button to the collection index page
- Added edit and delete buttons to record detail pages
- Added Discogs integration for automatic matching of records to releases
- Created comprehensive documentation for the Discogs integration system
- Added rake tasks for managing Discogs matching and validation

### How to test?

1. Visit the records index page and click "Add Record" to create a new record
2. Use the autocomplete fields to search for artists and labels
3. View a record and test the edit and delete functionality
4. Run Discogs commands to see matching statistics:
   ```bash
   bin/rails discogs:stats
   bin/rails discogs:validation_status
   bin/rails discogs:match
   ```
5. Visit `/admin/discogs_review` to manually review uncertain matches

### Why make this change?

This change enables users to manage their record collection directly through the application interface rather than requiring database manipulation. The Discogs integration provides automated price validation and metadata enrichment, ensuring accurate record information and helping identify valuable items in the collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create, edit, and delete vinyl records with a complete form
  * Autocomplete search functionality added for artist and label selection
  * "Add Record" button added to the records index for quick access
  * Edit and delete options available on individual record pages

* **Documentation**
  * Discogs integration guide published

<!-- end of auto-generated comment: release notes by coderabbit.ai -->