### PR TITLE
deploy

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -10,7 +10,7 @@ servers:
     cmd: bundle exec sidekiq -C config/sidekiq.yml
 
 proxy:
-  ssl: true
+  ssl: false
   host: recordtemple.com
   app_port: 3000
   healthcheck:


### PR DESCRIPTION
### TL;DR

Disabled SSL in the deployment configuration.

### What changed?

Changed the `ssl` setting from `true` to `false` in the proxy configuration section of `config/deploy.yml`.

### How to test?

1. Deploy the application with this configuration
2. Verify that the application is accessible via HTTP instead of HTTPS
3. Confirm that the proxy is correctly routing traffic to the application on port 3000

### Why make this change?

This change disables SSL termination at the proxy level, which may be necessary if:
- SSL termination is being handled by another layer in the infrastructure
- We're setting up a development or staging environment that doesn't require SSL
- We're troubleshooting SSL-related issues by temporarily disabling it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated proxy SSL configuration in deployment settings to disable SSL termination at the proxy layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->