### PR TITLE
more changes

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,14 +24,14 @@ Rails.application.configure do
   # Store uploaded files on S3 (see config/storage.yml for options).
   config.active_storage.service = :amazon
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # Cloudflare terminates SSL and forwards via HTTP with X-Forwarded-Proto: https
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Skip http-to-https redirect for the default health check endpoint (kamal-proxy hits /up over HTTP).
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
@@ -80,11 +80,11 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts = [
+    "recordtemple.com",
+    /.*\.recordtemple\.com/
+  ]
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
### TL;DR

Enable SSL and configure host authorization for production environment.

### What changed?

- Enabled `assume_ssl` to handle Cloudflare's SSL termination
- Enabled `force_ssl` to enforce HTTPS access
- Configured `ssl_options` to exclude health check endpoint from HTTPS redirection
- Added host authorization for `recordtemple.com` and its subdomains
- Configured host authorization to exclude the health check endpoint

### How to test?

1. Deploy to production and verify that all traffic is redirected to HTTPS
2. Verify that the `/up` health check endpoint remains accessible over HTTP
3. Confirm that requests with invalid host headers are rejected
4. Test that Cloudflare properly forwards traffic with the app correctly recognizing HTTPS

### Why make this change?

This change improves security by enforcing HTTPS connections and preventing host header attacks, while maintaining compatibility with Cloudflare as the SSL terminator and allowing the health check endpoint to function properly with kamal-proxy.