### PR TITLE
small

### DIFF
--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Resend.api_key = ENV["RESEND_API_KEY"]
+Resend.api_key = Rails.application.credentials.dig(:resend, :api_key)


### PR DESCRIPTION
### TL;DR

Updated Resend API key configuration to use Rails credentials instead of environment variables.

### What changed?

Changed the Resend API key configuration to retrieve the key from Rails credentials using `Rails.application.credentials.dig(:resend, :api_key)` instead of directly from environment variables with `ENV["RESEND_API_KEY"]`.

### How to test?

1. Ensure the Resend API key is properly set in your Rails credentials under the `:resend, :api_key` path
2. Verify that email functionality works as expected
3. Confirm that no errors occur when initializing the Resend client

### Why make this change?

This change improves security by using Rails' encrypted credentials system instead of environment variables for storing sensitive API keys. The credentials system provides better protection for secrets in version control and follows Rails best practices for configuration management.