### PR TITLE
small

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Admin
+  class BaseController < ApplicationController
+    before_action :require_admin
+
+    private
+
+    def require_admin
+      unless current_user&.admin?
+        redirect_to root_path, alert: "Admin access required"
+      end
+    end
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class DashboardController < ApplicationController
-    before_action :require_admin
-
+  class DashboardController < BaseController
     def index
     end
   end

--- a/app/controllers/admin/discogs_review_controller.rb
+++ b/app/controllers/admin/discogs_review_controller.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 module Admin
-  class DiscogsReviewController < ApplicationController
+  class DiscogsReviewController < BaseController
     COLLECTION_USER_ID = 1
 
-    before_action :require_admin
     before_action :set_record, only: [:show, :search, :link, :skip]
 
     # GET /admin/discogs_review
@@ -95,12 +94,6 @@ module Admin
     end
 
     private
-
-    def require_admin
-      unless current_user&.admin?
-        redirect_to root_path, alert: "Admin access required"
-      end
-    end
 
     def set_record
       @record = Record.where(user_id: COLLECTION_USER_ID).find(params[:id])

--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 module Admin
-  class RecordsController < ApplicationController
+  class RecordsController < BaseController
     COLLECTION_USER_ID = 1
-
-    before_action :require_admin
     before_action :set_record, only: [:edit, :update]
 
     CONFIDENCE_LEVELS = %w[High Medium Low Suspect].freeze
@@ -118,18 +116,13 @@ module Admin
       params.require(:record).permit(:value, :condition, :comment)
     end
 
-    def require_admin
-      unless current_user&.admin?
-        redirect_to root_path, alert: "Admin access required"
-      end
-    end
-
     def compute_stats(base_scope)
       valuation_scope = base_scope.with_valuation
 
       total_count = base_scope.count
       total_value = base_scope
         .joins("LEFT JOIN prices ON prices.id = records.price_id")
+        .joins("LEFT JOIN discogs_releases ON discogs_releases.id = records.discogs_release_id")
         .pick(Arel.sql("COALESCE(SUM(#{Record.best_value_sql}), 0)"))
         .to_f
 


### PR DESCRIPTION
### TL;DR

Refactored admin controllers to inherit from a new `BaseController` that centralizes admin authentication logic.

### What changed?

Created a new `Admin::BaseController` that handles admin authentication with a `require_admin` before_action. Updated `DashboardController`, `DiscogsReviewController`, and `RecordsController` to inherit from this base controller instead of `ApplicationController`, removing duplicate `require_admin` methods and before_actions from each controller.

### How to test?

1. Verify admin authentication still works by accessing admin routes as a non-admin user (should redirect to root with "Admin access required" message)
2. Confirm admin users can still access all admin functionality normally
3. Test all admin controller actions to ensure inheritance chain works correctly

### Why make this change?

This eliminates code duplication by consolidating the identical `require_admin` authentication logic that was repeated across multiple admin controllers into a single base controller, making the codebase more maintainable and following DRY principles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved admin access control by consolidating shared authentication logic, reducing code duplication across admin sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->