### PR TITLE
tiny

### DIFF
--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -140,8 +140,8 @@ module Admin
         redirect_to admin_record_path(@record), alert: "Invalid or expired attachment link."
         return
       end
-      matching_attachments = blob.attachments.where(record_type: "Record", record_id: @record.id)
-      if matching_attachments.none?
+      matching_attachments = blob.attachments.where(record_type: "Record", record_id: @record.id).to_a
+      if matching_attachments.empty?
         redirect_to admin_record_path(@record), alert: "Invalid or expired attachment link."
         return
       end

--- a/app/views/admin/records/show.html.erb
+++ b/app/views/admin/records/show.html.erb
@@ -147,7 +147,7 @@
 
       <details class="rounded-2xl bg-white shadow-sm ring-1 ring-olive-900/5">
         <summary class="cursor-pointer select-none px-6 py-4 text-xs font-semibold uppercase tracking-wide text-olive-500 hover:text-olive-700 transition-colors list-none flex items-center justify-between">
-          Audio Files (<%= @record.songs.size %>)
+          Audio Files (<%= @record.songs_count %>)
           <span class="text-olive-400 text-sm">▸</span>
         </summary>
         <div class="px-6 pb-6">


### PR DESCRIPTION
### TL;DR

Optimized database queries by converting ActiveRecord relation to array and using counter cache for songs count display.

### What changed?

- Modified `destroy_attachment` method to convert the `matching_attachments` query to an array using `.to_a` and changed the condition from `.none?` to `.empty?`
- Replaced `@record.songs.size` with `@record.songs_count` in the audio files section header

### How to test?

1. Navigate to an admin record page and verify the audio files count displays correctly
2. Test attachment deletion functionality to ensure it still works properly
3. Verify that invalid/expired attachment links still show appropriate error messages

### Why make this change?

The changes improve performance by avoiding unnecessary database queries. Converting to an array and using `.empty?` prevents multiple database calls, while using `songs_count` (likely a counter cache) eliminates the need to load and count all associated songs records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data handling and query execution for improved performance in the admin records section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->