### PR TITLE
rabbits

### DIFF
--- a/app/helpers/admin/records_helper.rb
+++ b/app/helpers/admin/records_helper.rb
@@ -8,22 +8,19 @@ module Admin
       discogs  = record[:discogs_lowest_price].to_f
       has_guide    = record[:price_high].to_i > 0
       has_personal = personal > 0
-      has_discogs  = discogs > 0
 
       fmt = ->(v) { "$#{number_with_delimiter(v.round(0))}" }
 
-      discogs_corr = has_discogs && (
-        (has_guide && guide > 0 && (discogs / guide).between?(1.0 / 3.0, 3.0)) ||
-        (has_personal && personal > 0 && (discogs / personal).between?(1.0 / 3.0, 3.0))
-      )
+      discogs_corr = RecordValuation.discogs_corresponds?(discogs, guide, personal)
 
       if has_guide && has_personal
         ratio = guide / personal
-        if    ratio >= 0.5 && ratio <= 2.0  then "Guide #{fmt.(guide)} and personal #{fmt.(personal)} agree (#{ratio.round(1)}×)"
-        elsif discogs_corr                   then "Discogs #{fmt.(discogs)} corroborates pricing"
-        elsif ratio >= 0.2 && ratio <= 5.0  then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — some disagreement (#{ratio.round(1)}×)"
-        elsif ratio > 5.0  && ratio <= 10.0 then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — significant gap (#{ratio.round(1)}×)"
-        else                                      "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — wildly different (#{ratio.round(1)}×)"
+        if    ratio >= RecordValuation::AGREE_MIN && ratio <= RecordValuation::AGREE_MAX              then "Guide #{fmt.(guide)} and personal #{fmt.(personal)} agree (#{ratio.round(1)}×)"
+        elsif discogs_corr                                                                             then "Discogs #{fmt.(discogs)} corroborates pricing"
+        elsif ratio >= RecordValuation::WEAK_AGREE_MIN && ratio <= RecordValuation::SOME_DISAGREE_MAX then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — some disagreement (#{ratio.round(1)}×)"
+        elsif ratio > RecordValuation::SOME_DISAGREE_MAX && ratio <= RecordValuation::SIGNIFICANT_GAP_MAX then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — significant gap (#{ratio.round(1)}×)"
+        elsif ratio >= 0.1 && ratio < RecordValuation::WEAK_AGREE_MIN                                    then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — large gap, low confidence (#{ratio.round(1)}×)"
+        else                                                                                               "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — wildly different, suspect (#{ratio.round(1)}×)"
         end
       elsif has_guide
         discogs_corr ? "Guide #{fmt.(guide)} corroborated by Discogs #{fmt.(discogs)}" : "Guide price only — set a personal value to improve confidence"

--- a/app/javascript/controllers/record_preview_controller.js
+++ b/app/javascript/controllers/record_preview_controller.js
@@ -52,7 +52,7 @@ export default class extends Controller {
 
     this.card.style.position = "fixed"
     this.card.style.zIndex = "9999"
-    this.card.style.left = `${Math.min(rect.left, window.innerWidth - cardWidth - margin)}px`
+    this.card.style.left = `${Math.max(margin, Math.min(rect.left, window.innerWidth - cardWidth - margin))}px`
 
     // Show below row; flip above if near bottom of viewport
     if (window.innerHeight - rect.bottom > 240) {

--- a/app/models/concerns/record_valuation.rb
+++ b/app/models/concerns/record_valuation.rb
@@ -3,6 +3,20 @@
 module RecordValuation
   extend ActiveSupport::Concern
 
+  AGREE_MIN           = 0.5
+  AGREE_MAX           = 2.0
+  WEAK_AGREE_MIN      = 0.2
+  SOME_DISAGREE_MAX   = 5.0
+  SIGNIFICANT_GAP_MAX = 10.0
+  DISCOGS_CORR_MIN    = 1.0 / 3.0
+  DISCOGS_CORR_MAX    = 3.0
+
+  def self.discogs_corresponds?(discogs, guide, personal)
+    return false unless discogs > 0
+    (guide > 0 && (discogs / guide).between?(DISCOGS_CORR_MIN, DISCOGS_CORR_MAX)) ||
+      (personal > 0 && (discogs / personal).between?(DISCOGS_CORR_MIN, DISCOGS_CORR_MAX))
+  end
+
   class_methods do
     # Condition multipliers against price_high (Goldmine scale)
     # condition enum: mint=1, near_mint=2, vg++=3, vg+=4, very_good=5, good=6, poor=7
@@ -65,27 +79,20 @@ module RecordValuation
       discogs   = row[:discogs_lowest_price].to_f
       has_guide    = row[:price_high].to_i > 0
       has_personal = personal > 0
-      has_discogs  = discogs > 0
 
       ratio = (has_guide && has_personal && personal > 0) ? guide_adj / personal : nil
-
-      discogs_corroborates = if has_discogs
-        (has_guide && guide_adj > 0 && (discogs / guide_adj).between?(1.0 / 3.0, 3.0)) ||
-        (has_personal && personal > 0 && (discogs / personal).between?(1.0 / 3.0, 3.0))
-      else
-        false
-      end
+      discogs_corroborates = RecordValuation.discogs_corresponds?(discogs, guide_adj, personal)
 
       if ratio
-        if ratio >= 0.5 && ratio <= 2.0
+        if ratio >= AGREE_MIN && ratio <= AGREE_MAX
           "High"
         elsif discogs_corroborates
           "High"
-        elsif ratio >= 0.2 && ratio <= 5.0
+        elsif ratio >= WEAK_AGREE_MIN && ratio <= SOME_DISAGREE_MAX
           "Medium"
-        elsif ratio > 5.0 && ratio <= 10.0
+        elsif ratio > SOME_DISAGREE_MAX && ratio <= SIGNIFICANT_GAP_MAX
           "Low"
-        elsif ratio > 10.0
+        elsif ratio > SIGNIFICANT_GAP_MAX
           "Suspect"
         elsif ratio < 0.1
           "Suspect"
@@ -93,7 +100,7 @@ module RecordValuation
           "Low"
         end
       elsif has_guide && !has_personal
-        has_discogs && discogs_corroborates ? "High" : "Medium"
+        discogs_corroborates ? "High" : "Medium"
       elsif !has_guide && has_personal
         "Medium"
       else

--- a/app/views/admin/records/show.html.erb
+++ b/app/views/admin/records/show.html.erb
@@ -67,7 +67,7 @@
             <% end %>
           <% else %>
             <p class="text-sm text-olive-400">No guide price linked</p>
-            <p class="mt-0.5 text-xs text-olive-300">Not yet matched to a Goldmine entry</p>
+            <p class="mt-0.5 text-xs text-olive-400">Not yet matched to a Goldmine entry</p>
           <% end %>
         </div>
         <div class="mt-4">
@@ -116,7 +116,7 @@
             <% end %>
           <% else %>
             <p class="text-sm text-olive-400">No Discogs match</p>
-            <p class="mt-0.5 text-xs text-olive-300">Not yet linked to a Discogs release</p>
+            <p class="mt-0.5 text-xs text-olive-400">Not yet linked to a Discogs release</p>
           <% end %>
         </div>
         <div class="mt-4">


### PR DESCRIPTION
### TL;DR

Refactored record valuation logic by extracting magic numbers into named constants and improved UI positioning and styling.

### What changed?

- Extracted hardcoded ratio thresholds (0.5, 2.0, 5.0, etc.) into named constants in the `RecordValuation` module (`AGREE_MIN`, `AGREE_MAX`, `SOME_DISAGREE_MAX`, etc.)
- Created a new `discogs_corresponds?` class method to centralize Discogs price correlation logic
- Enhanced confidence reason messaging to include "large gap, low confidence" and "wildly different, suspect" cases
- Fixed record preview card positioning to prevent it from appearing off the left edge of the screen
- Updated text color for "No guide price linked" and "No Discogs match" messages from `text-olive-300` to `text-olive-400`

### How to test?

- Navigate to admin record pages and verify that confidence reasons display correctly for records with different price ratios
- Test the record preview hover functionality near the left edge of the browser window to ensure cards stay visible
- Check that records without guide prices or Discogs matches show the updated text styling

### Why make this change?

The magic numbers scattered throughout the valuation logic made the code difficult to maintain and understand. By extracting these into named constants, the code becomes more readable and easier to modify. The UI improvements enhance user experience by preventing preview cards from being cut off and improving visual consistency in the admin interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview card positioning to prevent rendering outside visible screen boundaries.

* **Style**
  * Updated helper text color for improved visual clarity in the admin interface.

* **Refactor**
  * Standardized record valuation thresholds and introduced consistent evaluation logic to ensure reliable agreement assessments across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->