### PR TITLE
last

### DIFF
--- a/app/helpers/admin/records_helper.rb
+++ b/app/helpers/admin/records_helper.rb
@@ -19,7 +19,7 @@ module Admin
         elsif discogs_corr                                                                             then "Discogs #{fmt.(discogs)} corroborates pricing"
         elsif ratio >= RecordValuation::WEAK_AGREE_MIN && ratio <= RecordValuation::SOME_DISAGREE_MAX then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — some disagreement (#{ratio.round(1)}×)"
         elsif ratio > RecordValuation::SOME_DISAGREE_MAX && ratio <= RecordValuation::SIGNIFICANT_GAP_MAX then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — significant gap (#{ratio.round(1)}×)"
-        elsif ratio >= 0.1 && ratio < RecordValuation::WEAK_AGREE_MIN                                    then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — large gap, low confidence (#{ratio.round(1)}×)"
+        elsif ratio >= RecordValuation::SUSPECT_MIN && ratio < RecordValuation::WEAK_AGREE_MIN            then "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — large gap, low confidence (#{ratio.round(1)}×)"
         else                                                                                               "Guide #{fmt.(guide)} vs personal #{fmt.(personal)} — wildly different, suspect (#{ratio.round(1)}×)"
         end
       elsif has_guide

--- a/app/models/concerns/record_valuation.rb
+++ b/app/models/concerns/record_valuation.rb
@@ -8,6 +8,7 @@ module RecordValuation
   WEAK_AGREE_MIN      = 0.2
   SOME_DISAGREE_MAX   = 5.0
   SIGNIFICANT_GAP_MAX = 10.0
+  SUSPECT_MIN         = 0.1   # ratio below this → Suspect (wildly different)
   DISCOGS_CORR_MIN    = 1.0 / 3.0
   DISCOGS_CORR_MAX    = 3.0
 
@@ -43,7 +44,11 @@ module RecordValuation
       "GREATEST(#{adjusted_value_sql}, COALESCE(records.value, 0), COALESCE(discogs_releases.lowest_price, 0))"
     end
 
-    # SQL CASE expression for confidence — enables WHERE filtering and GROUP BY
+    # SQL CASE expression for confidence — enables WHERE filtering and GROUP BY.
+    # Threshold literals below mirror the Ruby constants above; keep in sync:
+    #   AGREE_MIN=0.5, AGREE_MAX=2.0, WEAK_AGREE_MIN=0.2, SOME_DISAGREE_MAX=5.0,
+    #   SIGNIFICANT_GAP_MAX=10.0, SUSPECT_MIN=0.1,
+    #   DISCOGS_CORR_MIN≈0.333, DISCOGS_CORR_MAX=3.0
     def confidence_sql
       guide_adj = adjusted_value_sql
       <<~SQL.squish
@@ -94,9 +99,9 @@ module RecordValuation
           "Low"
         elsif ratio > SIGNIFICANT_GAP_MAX
           "Suspect"
-        elsif ratio < 0.1
+        elsif ratio < SUSPECT_MIN
           "Suspect"
-        else # ratio 0.1–0.2
+        else # ratio SUSPECT_MIN–WEAK_AGREE_MIN (0.1–0.2)
           "Low"
         end
       elsif has_guide && !has_personal


### PR DESCRIPTION
### TL;DR

Replaced hardcoded ratio threshold `0.1` with named constant `SUSPECT_MIN` for better maintainability in record valuation confidence calculations.

### What changed?

- Added new constant `SUSPECT_MIN = 0.1` in the `RecordValuation` module
- Updated the confidence reason helper to use `RecordValuation::SUSPECT_MIN` instead of the hardcoded `0.1` value
- Enhanced SQL confidence method documentation to include all threshold constants for easier maintenance
- Updated the `compute_confidence` method to use the new constant and improved its inline comment

### How to test?

- Verify that record confidence calculations still work correctly for ratios around 0.1
- Check that records with guide vs personal value ratios between 0.1-0.2 still display "large gap, low confidence" messaging
- Ensure records with ratios below 0.1 are still classified as "Suspect"

### Why make this change?

This change eliminates magic numbers by centralizing the threshold value as a named constant, making the codebase more maintainable and reducing the risk of inconsistencies when threshold values need to be adjusted in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined confidence assessment logic to more accurately identify and flag records with large gaps and low confidence during valuation evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->