### PR TITLE
major fixes

### DIFF
--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -52,8 +52,12 @@ module Admin
       if params[:genre_id].present?
         records = records.where(genre_id: params[:genre_id])
       end
-      if params[:format_id].present?
-        records = records.where(record_format_id: params[:format_id])
+      if params[:format_category].present?
+        cat = params[:format_category]
+        records = records.where(
+          "record_formats.name = ? OR record_formats.name LIKE ?",
+          cat, "#{ActiveRecord::Base.sanitize_sql_like(cat)}: %"
+        )
       end
       if params[:condition].present?
         records = records.where(condition: params[:condition])
@@ -76,7 +80,7 @@ module Admin
       respond_to do |format|
         format.html do
           if top_n
-            total = [records.count, top_n].min
+            total = [records.unscope(:select, :order).count, top_n].min
             @pagy = Pagy.new(count: total, limit: 50, page: params[:page], overflow: :last_page)
             @records = records.offset(@pagy.offset).limit(@pagy.limit)
           else
@@ -203,12 +207,15 @@ module Admin
                      .pluck(Arel.sql("genres.id"), Arel.sql("genres.name"), Arel.sql("COUNT(records.id)"))
                      .map { |id, name, count| { id: id, name: name, count: count } }
 
-      @formats = RecordFormat.joins(:records)
-                              .where(records: { user_id: COLLECTION_USER_ID })
-                              .group("record_formats.id", "record_formats.name")
-                              .order(Arel.sql("COUNT(records.id) DESC"))
-                              .pluck(Arel.sql("record_formats.id"), Arel.sql("record_formats.name"), Arel.sql("COUNT(records.id)"))
-                              .map { |id, name, count| { id: id, name: name, count: count } }
+      raw_formats = RecordFormat.joins(:records)
+                                .where(records: { user_id: COLLECTION_USER_ID })
+                                .group("record_formats.name")
+                                .pluck("record_formats.name", Arel.sql("COUNT(records.id)"))
+      category_counts = raw_formats.each_with_object(Hash.new(0)) do |(name, count), h|
+        h[name.split(":").first.strip] += count
+      end
+      @format_categories = category_counts.sort_by { |_, count| -count }
+                                          .map { |name, count| { name: name, count: count } }
 
       @conditions = base.group(:condition)
                         .count

--- a/app/views/admin/records/_filter_bar.html.erb
+++ b/app/views/admin/records/_filter_bar.html.erb
@@ -109,18 +109,18 @@
       </select>
     <% end %>
 
-    <% if @formats.present? %>
-      <select name="format_id" aria-label="Format filter" data-action="change->auto-submit#submit"
+    <% if @format_categories.present? %>
+      <select name="format_category" aria-label="Format filter" data-action="change->auto-submit#submit"
               class="rounded-lg border-0 py-1.5 pl-3 pr-8 text-xs font-medium text-olive-700 ring-1 ring-inset ring-olive-900/10 focus:ring-2 focus:ring-olive-600 bg-white">
         <option value="">All Formats</option>
-        <% @formats.each do |f| %>
-          <option value="<%= f[:id] %>" <%= "selected" if params[:format_id].to_s == f[:id].to_s %>><%= f[:name] %> (<%= f[:count] %>)</option>
+        <% @format_categories.each do |f| %>
+          <option value="<%= f[:name] %>" <%= "selected" if params[:format_category] == f[:name] %>><%= f[:name] %> (<%= number_with_delimiter(f[:count]) %>)</option>
         <% end %>
       </select>
     <% end %>
 
     <%# Clear filters %>
-    <% if params.slice(:search, :confidence, :pricing, :condition, :genre_id, :format_id, :min_value, :price_source, :top_n).values.any?(&:present?) %>
+    <% if params.slice(:search, :confidence, :pricing, :condition, :genre_id, :format_category, :min_value, :price_source, :top_n).values.any?(&:present?) %>
       <%= link_to "Clear filters", admin_records_path,
           class: "text-xs font-medium text-olive-500 hover:text-olive-700 underline underline-offset-2" %>
     <% end %>


### PR DESCRIPTION
### TL;DR

Replaced format filtering by specific format ID with category-based filtering that groups formats by their base category name.

### What changed?

- Changed the format filter parameter from `format_id` to `format_category`
- Modified the filtering logic to match records where the format name equals the category or starts with the category followed by a colon
- Updated `load_filter_options` to group formats by category (text before the first colon) and aggregate their counts
- Fixed a count query issue by adding `unscope(:select, :order)` when calculating totals for top N results
- Updated the filter bar template to use format categories instead of individual format IDs
- Added number formatting with delimiters for format category counts in the dropdown

### How to test?

1. Navigate to the admin records page
2. Use the format filter dropdown to select different format categories
3. Verify that records are filtered correctly to show only those matching the selected category
4. Test that formats like "Vinyl: 12 inch" are included when filtering by "Vinyl" category
5. Confirm that the count numbers in the dropdown display with proper formatting (commas for thousands)

### Why make this change?

This change simplifies format filtering by grouping related formats into broader categories, making it easier for users to filter records without needing to know specific format IDs. It also provides a more intuitive user experience by allowing filtering on format types rather than exact format matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination calculation for large record sets.

* **Improvements**
  * Record filtering now groups formats by category for better organization.
  * Enhanced number formatting in filter options for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->