### PR TITLE
again

### DIFF
--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -56,7 +56,7 @@ module Admin
         cat = params[:format_category]
         records = records.where(
           "record_formats.name = ? OR record_formats.name LIKE ?",
-          cat, "#{ActiveRecord::Base.sanitize_sql_like(cat)}: %"
+          cat, "#{ActiveRecord::Base.sanitize_sql_like(cat)}:%"
         )
       end
       if params[:condition].present?


### PR DESCRIPTION
### TL;DR

Removed space after colon in record format category filtering query

### What changed?

Modified the SQL LIKE pattern in the records controller to use `"#{ActiveRecord::Base.sanitize_sql_like(cat)}:%"` instead of `"#{ActiveRecord::Base.sanitize_sql_like(cat)}: %"`, eliminating the space between the colon and percentage wildcard.

### How to test?

1. Navigate to the admin records page
2. Apply a format category filter
3. Verify that records with format names like "category:subcategory" are properly matched
4. Ensure no records are missed due to spacing issues in the format name pattern

### Why make this change?

The space after the colon was likely causing the query to miss records where the format name pattern doesn't include a space after the colon, improving the accuracy of the category filtering functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected format category filtering behavior to properly match intended record formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->