### PR TITLE
more details

### DIFF
--- a/app/views/records/_price_details.html.erb
+++ b/app/views/records/_price_details.html.erb
@@ -1,0 +1,8 @@
+<div class="mt-6 pt-6 border-t border-olive-100">
+  <% if record.detail.present? %>
+    <p class="text-sm text-olive-800"><%= record.detail %></p>
+  <% end %>
+  <% if record.footnote.present? %>
+    <p class="mt-1.5 text-xs text-olive-500"><%= record.footnote %></p>
+  <% end %>
+</div>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -116,30 +116,37 @@
           <%= render 'records/pressing_details', discogs_release: @record.discogs_release %>
         <% end %>
 
-        <% if @record.price_low.present? || @record.price_high.present? %>
-          <div class="mt-6 pt-6 border-t border-olive-100">
-            <p class="text-sm text-olive-500 mb-1">Estimated Value</p>
-            <p class="text-2xl font-semibold text-olive-950">
-              <% if @record.price_low.present? && @record.price_high.present? && @record.price_low != @record.price_high %>
-                $<%= @record.price_low %> – $<%= @record.price_high %>
-              <% elsif @record.price_high.present? %>
-                $<%= @record.price_high %>
-              <% elsif @record.price_low.present? %>
-                $<%= @record.price_low %>
-              <% end %>
-            </p>
-            <% if @record.yearbegin.present? || @record.yearend.present? %>
-              <p class="text-sm text-olive-500 mt-1">
-                <% if @record.yearbegin.present? && @record.yearend.present? && @record.yearbegin != @record.yearend %>
-                  Years: <%= @record.yearbegin %> – <%= @record.yearend %>
-                <% elsif @record.yearbegin.present? %>
-                  Year: <%= @record.yearbegin %>
-                <% elsif @record.yearend.present? %>
-                  Year: <%= @record.yearend %>
+        <%# Goldmine guide pressing description + footnote %>
+        <% if @record.detail.present? || @record.footnote.present? %>
+          <%= render 'records/price_details', record: @record %>
+        <% end %>
+
+        <% if current_user %>
+          <% if @record.price_low.present? || @record.price_high.present? %>
+            <div class="mt-6 pt-6 border-t border-olive-100">
+              <p class="text-sm text-olive-500 mb-1">Estimated Value</p>
+              <p class="text-2xl font-semibold text-olive-950">
+                <% if @record.price_low.present? && @record.price_high.present? && @record.price_low != @record.price_high %>
+                  $<%= @record.price_low %> – $<%= @record.price_high %>
+                <% elsif @record.price_high.present? %>
+                  $<%= @record.price_high %>
+                <% elsif @record.price_low.present? %>
+                  $<%= @record.price_low %>
                 <% end %>
               </p>
-            <% end %>
-          </div>
+              <% if @record.yearbegin.present? || @record.yearend.present? %>
+                <p class="text-sm text-olive-500 mt-1">
+                  <% if @record.yearbegin.present? && @record.yearend.present? && @record.yearbegin != @record.yearend %>
+                    Years: <%= @record.yearbegin %> – <%= @record.yearend %>
+                  <% elsif @record.yearbegin.present? %>
+                    Year: <%= @record.yearbegin %>
+                  <% elsif @record.yearend.present? %>
+                    Year: <%= @record.yearend %>
+                  <% end %>
+                </p>
+              <% end %>
+            </div>
+          <% end %>
         <% end %>
 
         <%# Discogs collector demand meter %>


### PR DESCRIPTION
### TL;DR

Added Goldmine guide pressing descriptions and footnotes to record pages, and restricted price information to authenticated users only.

### What changed?

- Created a new `_price_details.html.erb` partial to display record detail and footnote information from the Goldmine guide
- Added the price details partial to the record show page when detail or footnote data is present
- Wrapped the estimated value section in a `current_user` check to hide pricing information from unauthenticated visitors

### How to test?

1. Visit a record page while logged out - verify that estimated value pricing is not displayed
2. Log in and visit the same record page - confirm that estimated value pricing is now visible
3. Find a record with Goldmine guide detail or footnote data - verify that this information displays above the pricing section
4. Test records with only detail data, only footnote data, and both to ensure proper rendering

### Why make this change?

This change adds valuable Goldmine guide information to help users understand record pressing details while implementing user authentication requirements for sensitive pricing data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added price details section that displays additional information and footnotes when available.

* **Updated Features**
  * Pricing and estimated value information now requires user authentication to view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->