### PR TITLE
updates for grep

### DIFF
--- a/app/controllers/admin/discogs_review_controller.rb
+++ b/app/controllers/admin/discogs_review_controller.rb
@@ -12,7 +12,7 @@ module Admin
 
       # Cache the scope to avoid duplicate queries
       base_scope = review_queue_scope
-        .includes(:artist, :label, :price, :discogs_release, images_attachments: :blob)
+        .includes(:artist, :label, :genre, :record_format, :price, :discogs_release, images_attachments: :blob)
         .order("prices.price_high DESC NULLS LAST")
 
       @pagy, @records = pagy(base_scope, items: 25)

--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -13,7 +13,7 @@ module Admin
       # Apply text search via subquery to avoid pg_search rank column
       # conflicting with with_valuation's explicit SELECT list
       if params[:search].present?
-        search_ids = Record.wide_search(params[:search]).select(:id)
+        search_ids = base.wide_search(params[:search]).reselect(:id)
         base = base.where(id: search_ids)
       end
 

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -93,6 +93,7 @@ class Record < ApplicationRecord
   delegate :name, to: :artist, prefix: true, allow_nil: true
   delegate :name, to: :label, prefix: true, allow_nil: true
   delegate :name, to: :record_format, prefix: true, allow_nil: true
+  delegate :name, to: :genre, prefix: true, allow_nil: true
 
   delegate :price_high, :price_low, :yearbegin, :yearend, :detail, :footnote, to: :price, prefix: false, allow_nil: true
 

--- a/app/views/records/_record_list.html.erb
+++ b/app/views/records/_record_list.html.erb
@@ -59,7 +59,7 @@
                   </p>
                   <p class="text-sm text-olive-500 truncate mt-0.5">
                     <% subtitle = record.detail.presence || record.breadcrumb_title.presence %>
-                    <% year = record.yearbegin.present? && record.yearbegin > 0 ? record.yearbegin : nil %>
+                    <% year = (record.yearbegin.present? && record.yearbegin > 0) ? record.yearbegin : (record.yearend.present? && record.yearend > 0 ? record.yearend : nil) %>
                     <% if subtitle.present? %>
                       <%= subtitle %><% if year %> · <%= year %><% end %>
                     <% elsif year %>
@@ -78,7 +78,7 @@
               <span class="text-sm text-olive-600 truncate block"><%= record.record_format_name.presence || "—" %></span>
             </td>
             <td class="hidden px-4 lg:table-cell" style="padding-top: 0.75rem; padding-bottom: 0.75rem;">
-              <span class="text-sm text-olive-600 truncate block"><%= record.genre&.name.presence || "—" %></span>
+              <span class="text-sm text-olive-600 truncate block"><%= (record[:genre_name].presence || record.genre_name).presence || "—" %></span>
             </td>
             <td class="px-4 text-center" style="padding-top: 0.75rem; padding-bottom: 0.75rem;">
               <%= render 'records/condition_badge', condition: record.condition %>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -42,7 +42,7 @@
                 Unknown Artist
               <% end %>
             </h1>
-            <p class="mt-1 text-olive-600 whitespace-nowrap">
+            <p class="mt-1 text-olive-600 md:whitespace-nowrap">
               <% if @record.label.present? %>
                 <%= link_to @record.label_name, label_path(@record.label),
                     class: "hover:text-olive-800 transition-colors" %>


### PR DESCRIPTION
### TL;DR

Optimized database queries by adding eager loading for genre and record_format associations, and improved year display logic to fallback to yearend when yearbegin is unavailable.

### What changed?

- Added `genre` and `record_format` to the includes clause in the Discogs review controller to prevent N+1 queries
- Fixed search functionality in records controller by using `reselect(:id)` instead of `select(:id)` on the base scope
- Added `genre_name` delegate method to the Record model for consistent attribute access
- Enhanced year display logic to show `yearend` when `yearbegin` is not available or zero
- Updated genre name display to use preloaded attribute when available
- Removed `whitespace-nowrap` constraint on mobile devices for better text wrapping

### How to test?

- Navigate to the admin Discogs review page and verify that genre and format information loads without additional database queries
- Test the search functionality in the admin records section to ensure it returns correct results
- Check record listings to confirm that years display properly when only `yearend` is available
- Verify that genre names appear correctly in record lists
- Test the record detail page on mobile devices to ensure proper text wrapping

### Why make this change?

This change addresses performance issues by reducing database queries through proper eager loading and fixes display inconsistencies in year information. The search fix ensures that filtered results work correctly with the existing query scope, while the mobile layout improvement enhances user experience on smaller screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved year display logic with fallback when primary year is unavailable.
  * Enhanced genre display to show a placeholder character when genre information is missing.

* **New Features**
  * Added genre name attribute to record details.

* **Style**
  * Made text wrapping behavior responsive on smaller screens.

* **Refactor**
  * Refined search functionality within collection context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->