### PR TITLE
more updates

### DIFF
--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class RecordsController < BaseController
     COLLECTION_USER_ID = 1
-    before_action :set_record, only: [:show, :edit, :update, :add_images, :add_songs, :destroy_attachment, :preview]
+    before_action :set_record, only: [:show, :edit, :update, :destroy, :add_images, :add_songs, :destroy_attachment, :preview]
 
     CONFIDENCE_LEVELS = %w[High Medium Low Suspect].freeze
 
@@ -118,6 +118,11 @@ module Admin
         @formats = RecordFormat.order(:name)
         render :show, status: :unprocessable_entity
       end
+    end
+
+    def destroy
+      @record.destroy
+      redirect_to admin_records_path, notice: "Record deleted."
     end
 
     def preview

--- a/app/views/admin/records/show.html.erb
+++ b/app/views/admin/records/show.html.erb
@@ -323,4 +323,25 @@
     </div>
   </details>
 
+  <%# Danger Zone %>
+  <div class="mt-8 border border-red-200 rounded-xl overflow-hidden">
+    <details class="group">
+      <summary class="flex items-center justify-between px-4 py-3 bg-red-50 cursor-pointer list-none">
+        <span class="text-sm font-medium text-red-700">Danger Zone</span>
+        <svg class="w-4 h-4 text-red-400 group-open:rotate-180 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </summary>
+      <div class="px-4 py-4 bg-white">
+        <p class="text-sm text-olive-600 mb-4">Permanently delete this record and all associated data. This cannot be undone.</p>
+        <%= button_to admin_record_path(@record),
+            method: :delete,
+            form: { data: { turbo_confirm: "Permanently delete this record? This cannot be undone." } },
+            class: "inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 transition-colors" do %>
+          Delete Record Permanently
+        <% end %>
+      </div>
+    </details>
+  </div>
+
 </div>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -32,7 +32,15 @@
       </div>
 
       <div class="p-8 md:p-10 flex-1">
-        <div class="flex items-start justify-between gap-4">
+        <div>
+          <div class="flex items-center gap-2 mb-2">
+            <% if @record.discogs_release.present? %>
+              <%= render 'records/discogs_badge', record: @record %>
+            <% end %>
+            <% if @record.condition.present? %>
+              <%= render 'records/condition_badge', condition: @record.condition %>
+            <% end %>
+          </div>
           <div>
             <h1 class="font-display text-2xl sm:text-3xl tracking-tight text-olive-950">
               <% if @record.artist.present? %>
@@ -42,28 +50,20 @@
                 Unknown Artist
               <% end %>
             </h1>
-            <p class="mt-1 text-olive-600 md:whitespace-nowrap">
+            <p class="mt-1 text-sm text-olive-600">
               <% if @record.label.present? %>
                 <%= link_to @record.label_name, label_path(@record.label),
                     class: "hover:text-olive-800 transition-colors" %>
               <% else %>
                 Unknown Label
               <% end %>
-              <% if @record.record_format_name.present? %>
+              <% if @record.detail.present? %>
                 <span class="text-olive-400 mx-1.5">&middot;</span>
-                <%= @record.record_format_name %>
+                <%= @record.detail %>
               <% end %>
             </p>
-            <% if @record.detail.present? %>
-              <p class="mt-1.5 text-sm text-olive-600"><%= @record.detail %></p>
-            <% end %>
-          </div>
-          <div class="flex items-center gap-2">
-            <% if @record.discogs_release.present? %>
-              <%= render 'records/discogs_badge', record: @record %>
-            <% end %>
-            <% if @record.condition.present? %>
-              <%= render 'records/condition_badge', condition: @record.condition %>
+            <% if @record.record_format_name.present? %>
+              <p class="mt-0.5 text-sm text-olive-500"><%= @record.record_format_name %></p>
             <% end %>
           </div>
         </div>
@@ -71,21 +71,12 @@
         <%# Admin actions - visible only when logged in %>
         <% if current_user %>
           <div class="flex items-center gap-2 mt-4">
-            <%= link_to edit_record_path(@record),
+            <%= link_to admin_record_path(@record),
                 class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-olive-700 bg-olive-100 rounded-lg hover:bg-olive-200 transition-colors" do %>
               <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
               </svg>
               Edit
-            <% end %>
-            <%= button_to record_path(@record),
-                method: :delete,
-                form: { data: { turbo_confirm: "Are you sure you want to delete this record? This cannot be undone." } },
-                class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-red-700 bg-red-100 rounded-lg hover:bg-red-200 transition-colors" do %>
-              <svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
-              </svg>
-              Delete
             <% end %>
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # Admin area
   namespace :admin, constraints: AdminConstraint.new do
     root to: "dashboard#index"
-    resources :records, only: [:index, :show, :update] do
+    resources :records, only: [:index, :show, :update, :destroy] do
       member do
         patch :add_images
         patch :add_songs


### PR DESCRIPTION
### TL;DR

Added record deletion functionality to the admin interface with a "Danger Zone" section and moved delete action from public record view to admin-only area.

### What changed?

- Added `destroy` action to `Admin::RecordsController` that deletes records and redirects with a success notice
- Created a collapsible "Danger Zone" section in the admin record view with a delete button that includes confirmation dialog
- Removed the delete button from the public record view and changed the edit link to point to the admin record page
- Reorganized the record information layout in the public view, moving badges above the title and adjusting text styling
- Updated routes to include the `destroy` action for admin records

### How to test?

1. Log in as an admin user
2. Navigate to any record's admin page (`/admin/records/:id`)
3. Scroll to the bottom and expand the "Danger Zone" section
4. Click "Delete Record Permanently" and confirm the deletion
5. Verify the record is deleted and you're redirected to the admin records index
6. Check that the public record view no longer shows a delete button for logged-in users

### Why make this change?

This change improves security and user experience by restricting record deletion to the admin interface only, preventing accidental deletions from the public view. The "Danger Zone" pattern provides clear visual indication of destructive actions and requires explicit user interaction to access the delete functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added record deletion capability for administrators in a dedicated Danger Zone section with confirmation prompt.
  * Enhanced record display pages with condition and release badges.

* **Improvements**
  * Reorganized admin controls and actions for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->