### PR TITLE
redirect

### DIFF
--- a/app/controllers/admin/discogs_review_controller.rb
+++ b/app/controllers/admin/discogs_review_controller.rb
@@ -5,6 +5,7 @@ module Admin
     COLLECTION_USER_ID = 1
 
     before_action :set_record, only: [:show, :search, :link, :skip]
+    before_action :set_return_to, only: [:show, :search]
 
     # GET /admin/discogs_review
     def index
@@ -91,7 +92,7 @@ module Admin
         matching_service = DiscogsMatchingService.new(@record)
         matching_service.link!(discogs_release, confidence: 100, method: "manual")
 
-        redirect_to admin_discogs_review_index_path,
+        redirect_to safe_return_to(params[:return_to]),
           notice: "Linked '#{@record.title}' to Discogs ##{discogs_id}"
       rescue => e
         Rails.logger.error("Discogs link failed: #{e.class} - #{e.message}")
@@ -102,16 +103,16 @@ module Admin
     # POST /admin/discogs_review/:id/skip
     def skip
       if @record.update(discogs_skip_review: true, discogs_skip_reason: params[:reason])
-        redirect_to admin_discogs_review_index_path,
+        redirect_to safe_return_to(params[:return_to]),
           notice: "Marked '#{@record.title}' as skipped"
       else
         Rails.logger.error("Skip failed for record #{@record.id}: #{@record.errors.full_messages.join(', ')}")
-        redirect_to admin_discogs_review_path(@record),
+        redirect_to admin_discogs_review_path(@record, return_to: safe_return_to(params[:return_to])),
           alert: "Could not skip record, please try again."
       end
     rescue => e
       Rails.logger.error("Skip failed: #{e.class} - #{e.message}")
-      redirect_to admin_discogs_review_path(@record),
+      redirect_to admin_discogs_review_path(@record, return_to: safe_return_to(params[:return_to])),
         alert: "Could not skip record, please try again."
     end
 
@@ -119,6 +120,11 @@ module Admin
 
     def set_record
       @record = Record.where(user_id: COLLECTION_USER_ID).find(params[:id])
+    end
+
+    def set_return_to
+      @return_to = safe_return_to(params[:return_to])
+      @back_to_record = @return_to != admin_discogs_review_index_path
     end
 
     def review_queue_scope
@@ -162,7 +168,15 @@ module Admin
     end
 
     def redirect_with_error(message)
-      redirect_to admin_discogs_review_path(@record), alert: message
+      redirect_to admin_discogs_review_path(@record, return_to: safe_return_to(params[:return_to])), alert: message
+    end
+
+    def safe_return_to(path)
+      if path.is_a?(String) && !path.start_with?("//")
+        normalized = Pathname.new(path).cleanpath.to_s
+        return normalized if normalized.start_with?("/admin/", "/records/")
+      end
+      admin_discogs_review_index_path
     end
   end
 end

--- a/app/views/admin/discogs_review/show.html.erb
+++ b/app/views/admin/discogs_review/show.html.erb
@@ -1,11 +1,11 @@
 <div class="mx-auto max-w-4xl px-6 py-12">
   <%# Back link %>
   <div class="mb-4">
-    <%= link_to admin_discogs_review_index_path, class: "inline-flex items-center text-sm text-olive-600 hover:text-olive-950 transition-colors" do %>
+    <%= link_to @return_to, class: "inline-flex items-center text-sm text-olive-600 hover:text-olive-950 transition-colors" do %>
       <svg class="h-4 w-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
       </svg>
-      Back to Queue
+      <%= @back_to_record ? "Back to Record" : "Back to Queue" %>
     <% end %>
   </div>
 
@@ -54,6 +54,7 @@
 
       <%# Skip form flush right %>
       <%= form_with url: skip_admin_discogs_review_path(@record), method: :post, local: true, class: "flex items-center gap-2 flex-shrink-0" do |f| %>
+        <%= hidden_field_tag :return_to, @return_to %>
         <%= f.select :reason,
             [["No match found", "no_match"], ["Not on Discogs", "not_on_discogs"], ["Compilation/Various", "compilation"], ["Other", "other"]],
             {},
@@ -72,6 +73,7 @@
     <div class="p-6">
       <%# Search form %>
       <%= form_with url: search_admin_discogs_review_path(@record), method: :post, data: { turbo: false }, class: "mb-6" do |f| %>
+        <%= hidden_field_tag :return_to, @return_to %>
         <div class="flex space-x-2">
           <%= f.text_field :query,
               value: params[:query].presence || @auto_query,
@@ -121,7 +123,7 @@
                       rel: "noopener noreferrer",
                       class: "inline-flex items-center px-2.5 py-1.5 border border-olive-300 shadow-sm text-xs font-medium rounded-lg text-olive-700 bg-white hover:bg-olive-50 transition-colors" %>
                   <%= button_to "Link",
-                      link_admin_discogs_review_path(@record, discogs_id: candidate["id"]),
+                      link_admin_discogs_review_path(@record, discogs_id: candidate["id"], return_to: @return_to),
                       method: :post,
                       class: "inline-flex items-center px-2.5 py-1.5 border border-transparent shadow-sm text-xs font-medium rounded-lg text-white bg-olive-950 hover:bg-olive-800 transition-colors" %>
                 </div>
@@ -147,6 +149,7 @@
       <div class="mt-6 pt-6 border-t border-olive-200">
         <h4 class="text-sm font-medium text-olive-950 mb-2">Or enter Discogs ID directly</h4>
         <%= form_with url: link_admin_discogs_review_path(@record), method: :post, local: true, class: "flex space-x-2" do |f| %>
+          <%= hidden_field_tag :return_to, @return_to %>
           <%= f.number_field :discogs_id,
               placeholder: "e.g. 12345678",
               min: 1,

--- a/app/views/admin/records/show.html.erb
+++ b/app/views/admin/records/show.html.erb
@@ -1,11 +1,6 @@
 <div class="mx-auto max-w-5xl px-6 py-12 lg:px-10">
 
-  <%# Flash notices %>
-  <% if notice.present? %>
-    <div class="mb-6 rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700 ring-1 ring-emerald-200">
-      <%= notice %>
-    </div>
-  <% end %>
+  <%# Flash is rendered globally in layouts/application.html.erb %>
 
   <%# Header %>
   <header class="mb-8">
@@ -134,7 +129,7 @@
           <% end %>
         </div>
         <div class="mt-4">
-          <%= link_to (@record.discogs_release_id? ? "Change Discogs link →" : "Search Discogs →"), admin_discogs_review_path(@record),
+          <%= link_to (@record.discogs_release_id? ? "Change Discogs link →" : "Search Discogs →"), admin_discogs_review_path(@record, return_to: admin_record_path(@record)),
               class: "text-xs font-medium text-olive-600 hover:text-olive-950 underline underline-offset-2 transition-colors" %>
         </div>
       </div>

--- a/test/integration/admin/discogs_review_return_to_test.rb
+++ b/test/integration/admin/discogs_review_return_to_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+require "passwordless/test_helpers"
+
+module Admin
+  # Covers the return_to plumbing added to the Discogs review flow (issue #380):
+  # linking/skipping from a record's admin page must return to that record, while
+  # the batch-queue workflow must still return to the queue.
+  #
+  # Covers both `link` and `skip`. `skip` is a pure DB update. `link` normally
+  # fetches from Discogs, but DiscogsReleaseService#find_or_fetch checks the DB
+  # first, so pre-seeding a DiscogsRelease with the posted discogs_id exercises the
+  # real link path with no API call (the suite has no stubbing gem). A dummy
+  # DISCOGS_API_TOKEN is set only so DiscogsApiClient's constructor — which the
+  # services build eagerly — doesn't raise; no request is made. `show` is not
+  # request-tested here because it always hits the live Discogs search API.
+  class DiscogsReviewReturnToTest < ActionDispatch::IntegrationTest
+    include Passwordless::TestHelpers::RequestTestCase
+
+    COLLECTION_USER_ID = Admin::DiscogsReviewController::COLLECTION_USER_ID
+
+    setup do
+      @original_discogs_token = ENV["DISCOGS_API_TOKEN"]
+      ENV["DISCOGS_API_TOKEN"] = "test-token"
+
+      @owner = User.find_or_create_by!(id: COLLECTION_USER_ID) do |u|
+        u.email = "collection-owner@example.com"
+      end
+      passwordless_sign_in(@owner)
+
+      @genre  = Genre.create!(name: "Test Genre")
+      @label  = Label.create!(name: "Test Label")
+      @format = RecordFormat.create!(name: "Test Format", record_type: RecordType.create!(name: "Test Type"))
+
+      @record = create_record("Skip Test Artist")
+    end
+
+    teardown do
+      ENV["DISCOGS_API_TOKEN"] = @original_discogs_token
+    end
+
+    test "skip with a record return_to redirects back to that record" do
+      post skip_admin_discogs_review_path(@record),
+        params: { reason: "no_match", return_to: admin_record_path(@record) }
+      assert_redirected_to admin_record_path(@record)
+      assert @record.reload.discogs_skip_review
+    end
+
+    test "skip without return_to redirects to the queue" do
+      post skip_admin_discogs_review_path(@record), params: { reason: "no_match" }
+      assert_redirected_to admin_discogs_review_index_path
+    end
+
+    test "skip with a protocol-relative return_to falls back to the queue" do
+      post skip_admin_discogs_review_path(@record),
+        params: { reason: "no_match", return_to: "//evil.com" }
+      assert_redirected_to admin_discogs_review_index_path
+    end
+
+    test "skip with a non-whitelisted return_to falls back to the queue" do
+      post skip_admin_discogs_review_path(@record),
+        params: { reason: "no_match", return_to: "/etc/passwd" }
+      assert_redirected_to admin_discogs_review_index_path
+    end
+
+    test "skip with a path-traversal return_to falls back to the queue" do
+      post skip_admin_discogs_review_path(@record),
+        params: { reason: "no_match", return_to: "/admin/../secret" }
+      assert_redirected_to admin_discogs_review_index_path
+    end
+
+    test "link with a record return_to redirects back to that record" do
+      release = seed_release(900_001)
+      post link_admin_discogs_review_path(@record),
+        params: { discogs_id: release.discogs_id, return_to: admin_record_path(@record) }
+      assert_redirected_to admin_record_path(@record)
+      assert_equal release, @record.reload.discogs_release
+    end
+
+    test "link without return_to redirects to the queue" do
+      release = seed_release(900_002)
+      post link_admin_discogs_review_path(@record),
+        params: { discogs_id: release.discogs_id }
+      assert_redirected_to admin_discogs_review_index_path
+      assert_equal release, @record.reload.discogs_release
+    end
+
+    test "link with a hostile return_to falls back to the queue but still links" do
+      release = seed_release(900_003)
+      post link_admin_discogs_review_path(@record),
+        params: { discogs_id: release.discogs_id, return_to: "//evil.com" }
+      assert_redirected_to admin_discogs_review_index_path
+      assert_equal release, @record.reload.discogs_release
+    end
+
+    private
+
+    # Pre-seed a DiscogsRelease so DiscogsReleaseService#find_or_fetch returns it
+    # from the DB and the link path runs without touching the Discogs API.
+    def seed_release(discogs_id)
+      DiscogsRelease.create!(discogs_id: discogs_id, title: "Seeded #{discogs_id}", fetched_at: Time.current)
+    end
+
+    def create_record(artist_name)
+      Record.create!(
+        user_id: COLLECTION_USER_ID,
+        condition: :mint,
+        artist: Artist.create!(name: artist_name),
+        genre: @genre,
+        label: @label,
+        record_format: @format
+      )
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Back” link and Discogs forms now preserve and pass a contextual return destination, labeling “Back to Record” vs “Back to Queue”.

* **Bug Fixes**
  * Discogs review actions now redirect to a validated prior location instead of a fixed queue view.
  * Return destinations are sanitized and restricted for safety.

* **UI**
  * Record page no longer renders local flash notices (handled globally); Discogs action link now includes the record return target.

* **Tests**
  * Added integration tests for return navigation and safety handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razrfly/recordtemple/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->